### PR TITLE
Add GitHub Pages deployment for Commitment app

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,49 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Commitment/package-lock.json
+      - name: Build Commitment app
+        working-directory: Commitment
+        run: |
+          npm ci
+          npm run build
+      - name: Prepare site
+        run: |
+          mkdir -p site/Commitment
+          cp Commitment/index.html site/Commitment/
+          cp -r Commitment/dist site/Commitment/
+          cp index.html site/index.html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Experiments</title>
+</head>
+<body>
+  <h1>Experiments</h1>
+  <ul>
+    <li><a href="Commitment/">Commitment App</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add workflow to build Commitment app and publish to GitHub Pages
- Include root index page linking to Commitment app

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abca513584832aacffdb32f6ab4262