### PR TITLE
Switch commitment toggles to radio buttons

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -7,25 +7,21 @@ function isSameDay(a, b) {
         a.getMonth() === b.getMonth() &&
         a.getDate() === b.getDate();
 }
-function updateLabel(toggle, label) {
-    label.textContent = toggle.checked ? 'Yes' : 'No';
-}
-function scheduleLock(firstSetAt, toggle) {
+function scheduleLock(firstSetAt, radios) {
+    const disableRadios = () => radios.forEach(r => r.disabled = true);
     const remaining = LOCK_DURATION_MS - (Date.now() - firstSetAt);
     if (remaining <= 0) {
-        toggle.disabled = true;
+        disableRadios();
     }
     else {
-        setTimeout(() => {
-            toggle.disabled = true;
-        }, remaining);
+        setTimeout(disableRadios, remaining);
     }
 }
 export function setup() {
-    const commitToggle = document.getElementById('commit-toggle');
-    const commitLabel = document.getElementById('commit-label');
-    const heldToggle = document.getElementById('held-toggle');
-    const heldLabel = document.getElementById('held-label');
+    const commitYes = document.getElementById('commit-yes');
+    const commitNo = document.getElementById('commit-no');
+    const heldYes = document.getElementById('held-yes');
+    const heldNo = document.getElementById('held-no');
     // daily reset for commit
     const firstSetRaw = localStorage.getItem(COMMIT_TIME_KEY);
     if (firstSetRaw) {
@@ -37,29 +33,43 @@ export function setup() {
     }
     const savedCommit = localStorage.getItem(COMMIT_KEY);
     if (savedCommit !== null) {
-        commitToggle.checked = savedCommit === 'true';
-        updateLabel(commitToggle, commitLabel);
+        if (savedCommit === 'true') {
+            commitYes.checked = true;
+        }
+        else {
+            commitNo.checked = true;
+        }
         const firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
-        scheduleLock(firstSetAt, commitToggle);
+        scheduleLock(firstSetAt, [commitYes, commitNo]);
     }
     const savedHeld = localStorage.getItem(HELD_KEY);
     if (savedHeld !== null) {
-        heldToggle.checked = savedHeld === 'true';
-        updateLabel(heldToggle, heldLabel);
-    }
-    commitToggle.addEventListener('change', () => {
-        updateLabel(commitToggle, commitLabel);
-        localStorage.setItem(COMMIT_KEY, String(commitToggle.checked));
-        let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
-        if (!firstSetAt) {
-            firstSetAt = Date.now();
-            localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
-            scheduleLock(firstSetAt, commitToggle);
+        if (savedHeld === 'true') {
+            heldYes.checked = true;
         }
+        else {
+            heldNo.checked = true;
+        }
+    }
+    const commitRadios = document.querySelectorAll('input[name="commit"]');
+    commitRadios.forEach(radio => {
+        radio.addEventListener('change', () => {
+            const value = document.querySelector('input[name="commit"]:checked').value === 'yes';
+            localStorage.setItem(COMMIT_KEY, String(value));
+            let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
+            if (!firstSetAt) {
+                firstSetAt = Date.now();
+                localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
+                scheduleLock(firstSetAt, [commitYes, commitNo]);
+            }
+        });
     });
-    heldToggle.addEventListener('change', () => {
-        updateLabel(heldToggle, heldLabel);
-        localStorage.setItem(HELD_KEY, String(heldToggle.checked));
+    const heldRadios = document.querySelectorAll('input[name="held"]');
+    heldRadios.forEach(radio => {
+        radio.addEventListener('change', () => {
+            const value = document.querySelector('input[name="held"]:checked').value === 'yes';
+            localStorage.setItem(HELD_KEY, String(value));
+        });
     });
 }
 document.addEventListener('DOMContentLoaded', setup);

--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -7,12 +7,14 @@
 <body>
   <h1>Today?</h1>
   <div>
-    <label>Commit: <input type="checkbox" id="commit-toggle"></label>
-    <span id="commit-label">No</span>
+    <span>Commit:</span>
+    <label><input type="radio" name="commit" id="commit-yes" value="yes"> Yes</label>
+    <label><input type="radio" name="commit" id="commit-no" value="no" checked> No</label>
   </div>
   <div>
-    <label>Held it: <input type="checkbox" id="held-toggle"></label>
-    <span id="held-label">No</span>
+    <span>Held it:</span>
+    <label><input type="radio" name="held" id="held-yes" value="yes"> Yes</label>
+    <label><input type="radio" name="held" id="held-no" value="no" checked> No</label>
   </div>
   <script type="module" src="./dist/main.js"></script>
 </body>

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -4,12 +4,14 @@ describe('Commitment UI', () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <div>
-        <label>Commit: <input type="checkbox" id="commit-toggle"></label>
-        <span id="commit-label">No</span>
+        <span>Commit:</span>
+        <label><input type="radio" name="commit" id="commit-yes" value="yes"> Yes</label>
+        <label><input type="radio" name="commit" id="commit-no" value="no"> No</label>
       </div>
       <div>
-        <label>Held it: <input type="checkbox" id="held-toggle"></label>
-        <span id="held-label">No</span>
+        <span>Held it:</span>
+        <label><input type="radio" name="held" id="held-yes" value="yes"> Yes</label>
+        <label><input type="radio" name="held" id="held-no" value="no"> No</label>
       </div>`;
     localStorage.clear();
     jest.useFakeTimers();
@@ -24,18 +26,20 @@ describe('Commitment UI', () => {
     localStorage.setItem('commitFirstSetAt', String(Date.now()));
     localStorage.setItem('heldToggle', 'true');
     setup();
-    const commit = document.getElementById('commit-toggle') as HTMLInputElement;
-    const held = document.getElementById('held-toggle') as HTMLInputElement;
-    expect(commit.checked).toBe(true);
-    expect(held.checked).toBe(true);
+    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
+    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+    expect(commitYes.checked).toBe(true);
+    expect(heldYes.checked).toBe(true);
   });
 
   it('locks commit toggle after 30 seconds', () => {
     setup();
-    const commit = document.getElementById('commit-toggle') as HTMLInputElement;
-    commit.checked = true;
-    commit.dispatchEvent(new Event('change'));
+    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
+    commitYes.checked = true;
+    commitYes.dispatchEvent(new Event('change'));
     jest.advanceTimersByTime(30000);
-    expect(commit.disabled).toBe(true);
+    const commitNo = document.getElementById('commit-no') as HTMLInputElement;
+    expect(commitYes.disabled).toBe(true);
+    expect(commitNo.disabled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- replace commitment and held checkboxes with yes/no radio groups
- update logic to persist and lock selections
- adjust tests for radio button interface

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abcd6706f4832a82d8b71001a55ba1