### PR TITLE
feat: allow clearing choices and lock commit after 30s

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -7,14 +7,14 @@ function isSameDay(a, b) {
         a.getMonth() === b.getMonth() &&
         a.getDate() === b.getDate();
 }
-function scheduleLock(firstSetAt, radios) {
-    const disableRadios = () => radios.forEach(r => r.disabled = true);
+function scheduleLock(firstSetAt, inputs) {
+    const disableInputs = () => inputs.forEach(r => r.disabled = true);
     const remaining = LOCK_DURATION_MS - (Date.now() - firstSetAt);
     if (remaining <= 0) {
-        disableRadios();
+        disableInputs();
     }
     else {
-        setTimeout(disableRadios, remaining);
+        setTimeout(disableInputs, remaining);
     }
 }
 export function setup() {
@@ -51,26 +51,50 @@ export function setup() {
             heldNo.checked = true;
         }
     }
-    const commitRadios = document.querySelectorAll('input[name="commit"]');
-    commitRadios.forEach(radio => {
-        radio.addEventListener('change', () => {
-            const value = document.querySelector('input[name="commit"]:checked').value === 'yes';
-            localStorage.setItem(COMMIT_KEY, String(value));
-            let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
-            if (!firstSetAt) {
-                firstSetAt = Date.now();
-                localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
-                scheduleLock(firstSetAt, [commitYes, commitNo]);
-            }
-        });
-    });
-    const heldRadios = document.querySelectorAll('input[name="held"]');
-    heldRadios.forEach(radio => {
-        radio.addEventListener('change', () => {
-            const value = document.querySelector('input[name="held"]:checked').value === 'yes';
-            localStorage.setItem(HELD_KEY, String(value));
-        });
-    });
+    const handleCommitChange = () => {
+        if (commitYes.checked) {
+            commitNo.checked = false;
+        }
+        else if (commitNo.checked) {
+            commitYes.checked = false;
+        }
+        if (commitYes.checked) {
+            localStorage.setItem(COMMIT_KEY, 'true');
+        }
+        else if (commitNo.checked) {
+            localStorage.setItem(COMMIT_KEY, 'false');
+        }
+        else {
+            localStorage.removeItem(COMMIT_KEY);
+        }
+        let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
+        if (!firstSetAt && (commitYes.checked || commitNo.checked)) {
+            firstSetAt = Date.now();
+            localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
+            scheduleLock(firstSetAt, [commitYes, commitNo]);
+        }
+    };
+    commitYes.addEventListener('change', handleCommitChange);
+    commitNo.addEventListener('change', handleCommitChange);
+    const handleHeldChange = () => {
+        if (heldYes.checked) {
+            heldNo.checked = false;
+        }
+        else if (heldNo.checked) {
+            heldYes.checked = false;
+        }
+        if (heldYes.checked) {
+            localStorage.setItem(HELD_KEY, 'true');
+        }
+        else if (heldNo.checked) {
+            localStorage.setItem(HELD_KEY, 'false');
+        }
+        else {
+            localStorage.removeItem(HELD_KEY);
+        }
+    };
+    heldYes.addEventListener('change', handleHeldChange);
+    heldNo.addEventListener('change', handleHeldChange);
 }
 document.addEventListener('DOMContentLoaded', setup);
 export { isSameDay }; // for testing

--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -9,13 +9,13 @@
   <h1>Today?</h1>
   <div>
     <span>Commit:</span>
-    <label><input type="radio" name="commit" id="commit-yes" value="yes"> Yes</label>
-    <label><input type="radio" name="commit" id="commit-no" value="no" checked> No</label>
+    <label><input type="checkbox" name="commit" id="commit-yes" value="yes"> Yes</label>
+    <label><input type="checkbox" name="commit" id="commit-no" value="no"> No</label>
   </div>
   <div>
     <span>Held it:</span>
-    <label><input type="radio" name="held" id="held-yes" value="yes"> Yes</label>
-    <label><input type="radio" name="held" id="held-no" value="no" checked> No</label>
+    <label><input type="checkbox" name="held" id="held-yes" value="yes"> Yes</label>
+    <label><input type="checkbox" name="held" id="held-no" value="no"> No</label>
   </div>
   <script type="module" src="./dist/main.js"></script>
 </body>

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -5,13 +5,13 @@ describe('Commitment UI', () => {
     document.body.innerHTML = `
       <div>
         <span>Commit:</span>
-        <label><input type="radio" name="commit" id="commit-yes" value="yes"> Yes</label>
-        <label><input type="radio" name="commit" id="commit-no" value="no"> No</label>
+        <label><input type="checkbox" name="commit" id="commit-yes" value="yes"> Yes</label>
+        <label><input type="checkbox" name="commit" id="commit-no" value="no"> No</label>
       </div>
       <div>
         <span>Held it:</span>
-        <label><input type="radio" name="held" id="held-yes" value="yes"> Yes</label>
-        <label><input type="radio" name="held" id="held-no" value="no"> No</label>
+        <label><input type="checkbox" name="held" id="held-yes" value="yes"> Yes</label>
+        <label><input type="checkbox" name="held" id="held-no" value="no"> No</label>
       </div>`;
     localStorage.clear();
     jest.useFakeTimers();
@@ -41,5 +41,19 @@ describe('Commitment UI', () => {
     const commitNo = document.getElementById('commit-no') as HTMLInputElement;
     expect(commitYes.disabled).toBe(true);
     expect(commitNo.disabled).toBe(true);
+  });
+
+  it('allows clearing a selection without selecting the other', () => {
+    setup();
+    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
+    const commitNo = document.getElementById('commit-no') as HTMLInputElement;
+    commitYes.checked = true;
+    commitYes.dispatchEvent(new Event('change'));
+    expect(commitYes.checked).toBe(true);
+    expect(commitNo.checked).toBe(false);
+    commitYes.checked = false;
+    commitYes.dispatchEvent(new Event('change'));
+    expect(commitYes.checked).toBe(false);
+    expect(commitNo.checked).toBe(false);
   });
 });

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -9,13 +9,13 @@ function isSameDay(a: Date, b: Date): boolean {
     a.getDate() === b.getDate();
 }
 
-function scheduleLock(firstSetAt: number, radios: HTMLInputElement[]) {
-  const disableRadios = () => radios.forEach(r => r.disabled = true);
+function scheduleLock(firstSetAt: number, inputs: HTMLInputElement[]) {
+  const disableInputs = () => inputs.forEach(r => r.disabled = true);
   const remaining = LOCK_DURATION_MS - (Date.now() - firstSetAt);
   if (remaining <= 0) {
-    disableRadios();
+    disableInputs();
   } else {
-    setTimeout(disableRadios, remaining);
+    setTimeout(disableInputs, remaining);
   }
 }
 
@@ -55,27 +55,50 @@ export function setup() {
     }
   }
 
-  const commitRadios = document.querySelectorAll('input[name="commit"]') as NodeListOf<HTMLInputElement>;
-  commitRadios.forEach(radio => {
-    radio.addEventListener('change', () => {
-      const value = (document.querySelector('input[name="commit"]:checked') as HTMLInputElement).value === 'yes';
-      localStorage.setItem(COMMIT_KEY, String(value));
-      let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
-      if (!firstSetAt) {
-        firstSetAt = Date.now();
-        localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
-        scheduleLock(firstSetAt, [commitYes, commitNo]);
-      }
-    });
-  });
+  const handleCommitChange = () => {
+    if (commitYes.checked) {
+      commitNo.checked = false;
+    } else if (commitNo.checked) {
+      commitYes.checked = false;
+    }
 
-  const heldRadios = document.querySelectorAll('input[name="held"]') as NodeListOf<HTMLInputElement>;
-  heldRadios.forEach(radio => {
-    radio.addEventListener('change', () => {
-      const value = (document.querySelector('input[name="held"]:checked') as HTMLInputElement).value === 'yes';
-      localStorage.setItem(HELD_KEY, String(value));
-    });
-  });
+    if (commitYes.checked) {
+      localStorage.setItem(COMMIT_KEY, 'true');
+    } else if (commitNo.checked) {
+      localStorage.setItem(COMMIT_KEY, 'false');
+    } else {
+      localStorage.removeItem(COMMIT_KEY);
+    }
+
+    let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
+    if (!firstSetAt && (commitYes.checked || commitNo.checked)) {
+      firstSetAt = Date.now();
+      localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
+      scheduleLock(firstSetAt, [commitYes, commitNo]);
+    }
+  };
+
+  commitYes.addEventListener('change', handleCommitChange);
+  commitNo.addEventListener('change', handleCommitChange);
+
+  const handleHeldChange = () => {
+    if (heldYes.checked) {
+      heldNo.checked = false;
+    } else if (heldNo.checked) {
+      heldYes.checked = false;
+    }
+
+    if (heldYes.checked) {
+      localStorage.setItem(HELD_KEY, 'true');
+    } else if (heldNo.checked) {
+      localStorage.setItem(HELD_KEY, 'false');
+    } else {
+      localStorage.removeItem(HELD_KEY);
+    }
+  };
+
+  heldYes.addEventListener('change', handleHeldChange);
+  heldNo.addEventListener('change', handleHeldChange);
 }
 
 document.addEventListener('DOMContentLoaded', setup);


### PR DESCRIPTION
## Summary
- implement checkbox-based yes/no inputs that start unselected and won't auto-select the opposite option
- lock commit choice after 30s and preserve selections

## Testing
- `npm run lint`
- `npm test`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68abd0b8afd4832a9b39c9683d61fe89