### PR TITLE
Ensure exclusive selection for Commitment checkboxes

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -51,11 +51,12 @@ export function setup() {
             heldNo.checked = true;
         }
     }
-    const handleCommitChange = () => {
-        if (commitYes.checked) {
+    const handleCommitChange = (ev) => {
+        const target = ev.target;
+        if (target === commitYes && commitYes.checked) {
             commitNo.checked = false;
         }
-        else if (commitNo.checked) {
+        else if (target === commitNo && commitNo.checked) {
             commitYes.checked = false;
         }
         if (commitYes.checked) {
@@ -76,11 +77,12 @@ export function setup() {
     };
     commitYes.addEventListener('change', handleCommitChange);
     commitNo.addEventListener('change', handleCommitChange);
-    const handleHeldChange = () => {
-        if (heldYes.checked) {
+    const handleHeldChange = (ev) => {
+        const target = ev.target;
+        if (target === heldYes && heldYes.checked) {
             heldNo.checked = false;
         }
-        else if (heldNo.checked) {
+        else if (target === heldNo && heldNo.checked) {
             heldYes.checked = false;
         }
         if (heldYes.checked) {

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -56,4 +56,28 @@ describe('Commitment UI', () => {
     expect(commitYes.checked).toBe(false);
     expect(commitNo.checked).toBe(false);
   });
+
+  it('does not allow both commit options to be selected', () => {
+    setup();
+    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
+    const commitNo = document.getElementById('commit-no') as HTMLInputElement;
+    commitYes.checked = true;
+    commitYes.dispatchEvent(new Event('change'));
+    commitNo.checked = true;
+    commitNo.dispatchEvent(new Event('change'));
+    expect(commitYes.checked).toBe(false);
+    expect(commitNo.checked).toBe(true);
+  });
+
+  it('does not allow both held options to be selected', () => {
+    setup();
+    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+    const heldNo = document.getElementById('held-no') as HTMLInputElement;
+    heldYes.checked = true;
+    heldYes.dispatchEvent(new Event('change'));
+    heldNo.checked = true;
+    heldNo.dispatchEvent(new Event('change'));
+    expect(heldYes.checked).toBe(false);
+    expect(heldNo.checked).toBe(true);
+  });
 });

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -55,10 +55,11 @@ export function setup() {
     }
   }
 
-  const handleCommitChange = () => {
-    if (commitYes.checked) {
+  const handleCommitChange = (ev: Event) => {
+    const target = ev.target as HTMLInputElement;
+    if (target === commitYes && commitYes.checked) {
       commitNo.checked = false;
-    } else if (commitNo.checked) {
+    } else if (target === commitNo && commitNo.checked) {
       commitYes.checked = false;
     }
 
@@ -81,10 +82,11 @@ export function setup() {
   commitYes.addEventListener('change', handleCommitChange);
   commitNo.addEventListener('change', handleCommitChange);
 
-  const handleHeldChange = () => {
-    if (heldYes.checked) {
+  const handleHeldChange = (ev: Event) => {
+    const target = ev.target as HTMLInputElement;
+    if (target === heldYes && heldYes.checked) {
       heldNo.checked = false;
-    } else if (heldNo.checked) {
+    } else if (target === heldNo && heldNo.checked) {
       heldYes.checked = false;
     }
 


### PR DESCRIPTION
## Summary
- Prevent both checkboxes from being simultaneously selected by tracking which input changed
- Add tests to verify exclusivity for commit and held options

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abd4090fe4832a934051b5be0f0663