### PR TITLE
Replace checkboxes with styled buttons

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -7,14 +7,14 @@ function isSameDay(a, b) {
         a.getMonth() === b.getMonth() &&
         a.getDate() === b.getDate();
 }
-function scheduleLock(firstSetAt, inputs) {
-    const disableInputs = () => inputs.forEach(r => r.disabled = true);
+function scheduleLock(firstSetAt, buttons) {
+    const disableButtons = () => buttons.forEach(r => r.disabled = true);
     const remaining = LOCK_DURATION_MS - (Date.now() - firstSetAt);
     if (remaining <= 0) {
-        disableInputs();
+        disableButtons();
     }
     else {
-        setTimeout(disableInputs, remaining);
+        setTimeout(disableButtons, remaining);
     }
 }
 export function setup() {
@@ -34,10 +34,10 @@ export function setup() {
     const savedCommit = localStorage.getItem(COMMIT_KEY);
     if (savedCommit !== null) {
         if (savedCommit === 'true') {
-            commitYes.checked = true;
+            commitYes.classList.add('selected');
         }
         else {
-            commitNo.checked = true;
+            commitNo.classList.add('selected');
         }
         const firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
         scheduleLock(firstSetAt, [commitYes, commitNo]);
@@ -45,58 +45,70 @@ export function setup() {
     const savedHeld = localStorage.getItem(HELD_KEY);
     if (savedHeld !== null) {
         if (savedHeld === 'true') {
-            heldYes.checked = true;
+            heldYes.classList.add('selected');
         }
         else {
-            heldNo.checked = true;
+            heldNo.classList.add('selected');
         }
     }
-    const handleCommitChange = (ev) => {
+    const handleCommitClick = (ev) => {
         const target = ev.target;
-        if (target === commitYes && commitYes.checked) {
-            commitNo.checked = false;
+        if (target === commitYes) {
+            const nowSelected = !commitYes.classList.contains('selected');
+            commitYes.classList.toggle('selected', nowSelected);
+            if (nowSelected)
+                commitNo.classList.remove('selected');
         }
-        else if (target === commitNo && commitNo.checked) {
-            commitYes.checked = false;
+        else if (target === commitNo) {
+            const nowSelected = !commitNo.classList.contains('selected');
+            commitNo.classList.toggle('selected', nowSelected);
+            if (nowSelected)
+                commitYes.classList.remove('selected');
         }
-        if (commitYes.checked) {
+        if (commitYes.classList.contains('selected')) {
             localStorage.setItem(COMMIT_KEY, 'true');
         }
-        else if (commitNo.checked) {
+        else if (commitNo.classList.contains('selected')) {
             localStorage.setItem(COMMIT_KEY, 'false');
         }
         else {
             localStorage.removeItem(COMMIT_KEY);
         }
         let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
-        if (!firstSetAt && (commitYes.checked || commitNo.checked)) {
+        if (!firstSetAt && (commitYes.classList.contains('selected') || commitNo.classList.contains('selected'))) {
             firstSetAt = Date.now();
             localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
             scheduleLock(firstSetAt, [commitYes, commitNo]);
         }
     };
-    commitYes.addEventListener('change', handleCommitChange);
-    commitNo.addEventListener('change', handleCommitChange);
-    const handleHeldChange = (ev) => {
+    commitYes.addEventListener('click', handleCommitClick);
+    commitNo.addEventListener('click', handleCommitClick);
+    const handleHeldClick = (ev) => {
         const target = ev.target;
-        if (target === heldYes && heldYes.checked) {
-            heldNo.checked = false;
+        if (target === heldYes) {
+            const nowSelected = !heldYes.classList.contains('selected');
+            heldYes.classList.toggle('selected', nowSelected);
+            if (nowSelected)
+                heldNo.classList.remove('selected');
         }
-        else if (target === heldNo && heldNo.checked) {
-            heldYes.checked = false;
+        else if (target === heldNo) {
+            const nowSelected = !heldNo.classList.contains('selected');
+            heldNo.classList.toggle('selected', nowSelected);
+            if (nowSelected)
+                heldYes.classList.remove('selected');
         }
-        if (heldYes.checked) {
+        if (heldYes.classList.contains('selected')) {
             localStorage.setItem(HELD_KEY, 'true');
         }
-        else if (heldNo.checked) {
+        else if (heldNo.classList.contains('selected')) {
             localStorage.setItem(HELD_KEY, 'false');
         }
         else {
             localStorage.removeItem(HELD_KEY);
         }
     };
-    heldYes.addEventListener('change', handleHeldChange);
-    heldNo.addEventListener('change', handleHeldChange);
+    heldYes.addEventListener('click', handleHeldClick);
+    heldNo.addEventListener('click', handleHeldClick);
 }
 document.addEventListener('DOMContentLoaded', setup);
 export { isSameDay }; // for testing

--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -4,18 +4,33 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Commitment</title>
+  <style>
+    body { font-family: sans-serif; }
+    .prompt { margin-bottom: 1em; }
+    .choice {
+      border: 2px solid;
+      background: transparent;
+      padding: 0.5em 1em;
+      margin-left: 0.5em;
+      cursor: pointer;
+    }
+    .choice.yes { border-color: green; color: green; }
+    .choice.no { border-color: red; color: red; }
+    .choice.selected.yes { background-color: green; color: white; }
+    .choice.selected.no { background-color: red; color: white; }
+  </style>
 </head>
 <body>
   <h1>Today?</h1>
-  <div>
+  <div class="prompt">
     <span>Commit:</span>
-    <label><input type="checkbox" name="commit" id="commit-yes" value="yes"> Yes</label>
-    <label><input type="checkbox" name="commit" id="commit-no" value="no"> No</label>
+    <button id="commit-yes" class="choice yes" type="button">Yes</button>
+    <button id="commit-no" class="choice no" type="button">No</button>
   </div>
-  <div>
+  <div class="prompt">
     <span>Held it:</span>
-    <label><input type="checkbox" name="held" id="held-yes" value="yes"> Yes</label>
-    <label><input type="checkbox" name="held" id="held-no" value="no"> No</label>
+    <button id="held-yes" class="choice yes" type="button">Yes</button>
+    <button id="held-no" class="choice no" type="button">No</button>
   </div>
   <script type="module" src="./dist/main.js"></script>
 </body>

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -5,13 +5,13 @@ describe('Commitment UI', () => {
     document.body.innerHTML = `
       <div>
         <span>Commit:</span>
-        <label><input type="checkbox" name="commit" id="commit-yes" value="yes"> Yes</label>
-        <label><input type="checkbox" name="commit" id="commit-no" value="no"> No</label>
+        <button id="commit-yes" class="choice yes" type="button">Yes</button>
+        <button id="commit-no" class="choice no" type="button">No</button>
       </div>
       <div>
         <span>Held it:</span>
-        <label><input type="checkbox" name="held" id="held-yes" value="yes"> Yes</label>
-        <label><input type="checkbox" name="held" id="held-no" value="no"> No</label>
+        <button id="held-yes" class="choice yes" type="button">Yes</button>
+        <button id="held-no" class="choice no" type="button">No</button>
       </div>`;
     localStorage.clear();
     jest.useFakeTimers();
@@ -26,58 +26,51 @@ describe('Commitment UI', () => {
     localStorage.setItem('commitFirstSetAt', String(Date.now()));
     localStorage.setItem('heldToggle', 'true');
     setup();
-    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
-    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
-    expect(commitYes.checked).toBe(true);
-    expect(heldYes.checked).toBe(true);
+    const commitYes = document.getElementById('commit-yes') as HTMLButtonElement;
+    const heldYes = document.getElementById('held-yes') as HTMLButtonElement;
+    expect(commitYes.classList.contains('selected')).toBe(true);
+    expect(heldYes.classList.contains('selected')).toBe(true);
   });
 
   it('locks commit toggle after 30 seconds', () => {
     setup();
-    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
-    commitYes.checked = true;
-    commitYes.dispatchEvent(new Event('change'));
+    const commitYes = document.getElementById('commit-yes') as HTMLButtonElement;
+    commitYes.click();
     jest.advanceTimersByTime(30000);
-    const commitNo = document.getElementById('commit-no') as HTMLInputElement;
+    const commitNo = document.getElementById('commit-no') as HTMLButtonElement;
     expect(commitYes.disabled).toBe(true);
     expect(commitNo.disabled).toBe(true);
   });
 
   it('allows clearing a selection without selecting the other', () => {
     setup();
-    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
-    const commitNo = document.getElementById('commit-no') as HTMLInputElement;
-    commitYes.checked = true;
-    commitYes.dispatchEvent(new Event('change'));
-    expect(commitYes.checked).toBe(true);
-    expect(commitNo.checked).toBe(false);
-    commitYes.checked = false;
-    commitYes.dispatchEvent(new Event('change'));
-    expect(commitYes.checked).toBe(false);
-    expect(commitNo.checked).toBe(false);
+    const commitYes = document.getElementById('commit-yes') as HTMLButtonElement;
+    const commitNo = document.getElementById('commit-no') as HTMLButtonElement;
+    commitYes.click();
+    expect(commitYes.classList.contains('selected')).toBe(true);
+    expect(commitNo.classList.contains('selected')).toBe(false);
+    commitYes.click();
+    expect(commitYes.classList.contains('selected')).toBe(false);
+    expect(commitNo.classList.contains('selected')).toBe(false);
   });
 
   it('does not allow both commit options to be selected', () => {
     setup();
-    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
-    const commitNo = document.getElementById('commit-no') as HTMLInputElement;
-    commitYes.checked = true;
-    commitYes.dispatchEvent(new Event('change'));
-    commitNo.checked = true;
-    commitNo.dispatchEvent(new Event('change'));
-    expect(commitYes.checked).toBe(false);
-    expect(commitNo.checked).toBe(true);
+    const commitYes = document.getElementById('commit-yes') as HTMLButtonElement;
+    const commitNo = document.getElementById('commit-no') as HTMLButtonElement;
+    commitYes.click();
+    commitNo.click();
+    expect(commitYes.classList.contains('selected')).toBe(false);
+    expect(commitNo.classList.contains('selected')).toBe(true);
   });
 
   it('does not allow both held options to be selected', () => {
     setup();
-    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
-    const heldNo = document.getElementById('held-no') as HTMLInputElement;
-    heldYes.checked = true;
-    heldYes.dispatchEvent(new Event('change'));
-    heldNo.checked = true;
-    heldNo.dispatchEvent(new Event('change'));
-    expect(heldYes.checked).toBe(false);
-    expect(heldNo.checked).toBe(true);
+    const heldYes = document.getElementById('held-yes') as HTMLButtonElement;
+    const heldNo = document.getElementById('held-no') as HTMLButtonElement;
+    heldYes.click();
+    heldNo.click();
+    expect(heldYes.classList.contains('selected')).toBe(false);
+    expect(heldNo.classList.contains('selected')).toBe(true);
   });
 });

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -9,21 +9,21 @@ function isSameDay(a: Date, b: Date): boolean {
     a.getDate() === b.getDate();
 }
 
-function scheduleLock(firstSetAt: number, inputs: HTMLInputElement[]) {
-  const disableInputs = () => inputs.forEach(r => r.disabled = true);
+function scheduleLock(firstSetAt: number, buttons: HTMLButtonElement[]) {
+  const disableButtons = () => buttons.forEach(r => r.disabled = true);
   const remaining = LOCK_DURATION_MS - (Date.now() - firstSetAt);
   if (remaining <= 0) {
-    disableInputs();
+    disableButtons();
   } else {
-    setTimeout(disableInputs, remaining);
+    setTimeout(disableButtons, remaining);
   }
 }
 
 export function setup() {
-  const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
-  const commitNo = document.getElementById('commit-no') as HTMLInputElement;
-  const heldYes = document.getElementById('held-yes') as HTMLInputElement;
-  const heldNo = document.getElementById('held-no') as HTMLInputElement;
+  const commitYes = document.getElementById('commit-yes') as HTMLButtonElement;
+  const commitNo = document.getElementById('commit-no') as HTMLButtonElement;
+  const heldYes = document.getElementById('held-yes') as HTMLButtonElement;
+  const heldNo = document.getElementById('held-no') as HTMLButtonElement;
 
   // daily reset for commit
   const firstSetRaw = localStorage.getItem(COMMIT_TIME_KEY);
@@ -38,9 +38,9 @@ export function setup() {
   const savedCommit = localStorage.getItem(COMMIT_KEY);
   if (savedCommit !== null) {
     if (savedCommit === 'true') {
-      commitYes.checked = true;
+      commitYes.classList.add('selected');
     } else {
-      commitNo.checked = true;
+      commitNo.classList.add('selected');
     }
     const firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
     scheduleLock(firstSetAt, [commitYes, commitNo]);
@@ -49,58 +49,66 @@ export function setup() {
   const savedHeld = localStorage.getItem(HELD_KEY);
   if (savedHeld !== null) {
     if (savedHeld === 'true') {
-      heldYes.checked = true;
+      heldYes.classList.add('selected');
     } else {
-      heldNo.checked = true;
+      heldNo.classList.add('selected');
     }
   }
 
-  const handleCommitChange = (ev: Event) => {
-    const target = ev.target as HTMLInputElement;
-    if (target === commitYes && commitYes.checked) {
-      commitNo.checked = false;
-    } else if (target === commitNo && commitNo.checked) {
-      commitYes.checked = false;
+  const handleCommitClick = (ev: Event) => {
+    const target = ev.target as HTMLButtonElement;
+    if (target === commitYes) {
+      const nowSelected = !commitYes.classList.contains('selected');
+      commitYes.classList.toggle('selected', nowSelected);
+      if (nowSelected) commitNo.classList.remove('selected');
+    } else if (target === commitNo) {
+      const nowSelected = !commitNo.classList.contains('selected');
+      commitNo.classList.toggle('selected', nowSelected);
+      if (nowSelected) commitYes.classList.remove('selected');
     }
 
-    if (commitYes.checked) {
+    if (commitYes.classList.contains('selected')) {
       localStorage.setItem(COMMIT_KEY, 'true');
-    } else if (commitNo.checked) {
+    } else if (commitNo.classList.contains('selected')) {
       localStorage.setItem(COMMIT_KEY, 'false');
     } else {
       localStorage.removeItem(COMMIT_KEY);
     }
 
     let firstSetAt = parseInt(localStorage.getItem(COMMIT_TIME_KEY) || '0', 10);
-    if (!firstSetAt && (commitYes.checked || commitNo.checked)) {
+    if (!firstSetAt && (commitYes.classList.contains('selected') || commitNo.classList.contains('selected'))) {
       firstSetAt = Date.now();
       localStorage.setItem(COMMIT_TIME_KEY, String(firstSetAt));
       scheduleLock(firstSetAt, [commitYes, commitNo]);
     }
   };
 
-  commitYes.addEventListener('change', handleCommitChange);
-  commitNo.addEventListener('change', handleCommitChange);
+  commitYes.addEventListener('click', handleCommitClick);
+  commitNo.addEventListener('click', handleCommitClick);
 
-  const handleHeldChange = (ev: Event) => {
-    const target = ev.target as HTMLInputElement;
-    if (target === heldYes && heldYes.checked) {
-      heldNo.checked = false;
-    } else if (target === heldNo && heldNo.checked) {
-      heldYes.checked = false;
+  const handleHeldClick = (ev: Event) => {
+    const target = ev.target as HTMLButtonElement;
+    if (target === heldYes) {
+      const nowSelected = !heldYes.classList.contains('selected');
+      heldYes.classList.toggle('selected', nowSelected);
+      if (nowSelected) heldNo.classList.remove('selected');
+    } else if (target === heldNo) {
+      const nowSelected = !heldNo.classList.contains('selected');
+      heldNo.classList.toggle('selected', nowSelected);
+      if (nowSelected) heldYes.classList.remove('selected');
     }
 
-    if (heldYes.checked) {
+    if (heldYes.classList.contains('selected')) {
       localStorage.setItem(HELD_KEY, 'true');
-    } else if (heldNo.checked) {
+    } else if (heldNo.classList.contains('selected')) {
       localStorage.setItem(HELD_KEY, 'false');
     } else {
       localStorage.removeItem(HELD_KEY);
     }
   };
 
-  heldYes.addEventListener('change', handleHeldChange);
-  heldNo.addEventListener('change', handleHeldChange);
+  heldYes.addEventListener('click', handleHeldClick);
+  heldNo.addEventListener('click', handleHeldClick);
 }
 
 document.addEventListener('DOMContentLoaded', setup);


### PR DESCRIPTION
## Summary
- Replace yes/no checkboxes with red and green outlined buttons that fill when selected
- Track button states and lock-in commit choice after 30 seconds
- Update tests for new button-based interface

## Testing
- `npm test`
- `npm run lint`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68abdc4e7070832a9238d514cd3a78a1