### PR TITLE
Style yes/no prompts as toggle buttons

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -22,6 +22,9 @@ export function setup() {
     const commitNo = document.getElementById('commit-no');
     const heldYes = document.getElementById('held-yes');
     const heldNo = document.getElementById('held-no');
+    if (!commitYes || !commitNo || !heldYes || !heldNo) {
+        return;
+    }
     // daily reset for commit
     const firstSetRaw = localStorage.getItem(COMMIT_TIME_KEY);
     if (firstSetRaw) {
@@ -98,5 +101,10 @@ export function setup() {
     heldYes.addEventListener('change', handleHeldChange);
     heldNo.addEventListener('change', handleHeldChange);
 }
-document.addEventListener('DOMContentLoaded', setup);
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setup);
+}
+else {
+    setup();
+}
 export { isSameDay }; // for testing

--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -4,18 +4,62 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Commitment</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 1rem;
+    }
+    .prompt {
+      margin-bottom: 1rem;
+    }
+    .option {
+      display: none;
+    }
+    .choice {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      border: 2px solid;
+      border-radius: 4px;
+      margin-left: 0.5rem;
+      cursor: pointer;
+    }
+    .choice.yes {
+      border-color: green;
+      color: green;
+    }
+    .choice.no {
+      border-color: red;
+      color: red;
+    }
+    .option:checked + .choice.yes {
+      background-color: green;
+      color: white;
+    }
+    .option:checked + .choice.no {
+      background-color: red;
+      color: white;
+    }
+    .option:disabled + .choice {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  </style>
 </head>
 <body>
   <h1>Today?</h1>
-  <div>
+  <div class="prompt">
     <span>Commit:</span>
-    <label><input type="checkbox" name="commit" id="commit-yes" value="yes"> Yes</label>
-    <label><input type="checkbox" name="commit" id="commit-no" value="no"> No</label>
+    <input type="checkbox" class="option" name="commit" id="commit-yes" value="yes">
+    <label for="commit-yes" class="choice yes">Yes</label>
+    <input type="checkbox" class="option" name="commit" id="commit-no" value="no">
+    <label for="commit-no" class="choice no">No</label>
   </div>
-  <div>
+  <div class="prompt">
     <span>Held it:</span>
-    <label><input type="checkbox" name="held" id="held-yes" value="yes"> Yes</label>
-    <label><input type="checkbox" name="held" id="held-no" value="no"> No</label>
+    <input type="checkbox" class="option" name="held" id="held-yes" value="yes">
+    <label for="held-yes" class="choice yes">Yes</label>
+    <input type="checkbox" class="option" name="held" id="held-no" value="no">
+    <label for="held-no" class="choice no">No</label>
   </div>
   <script type="module" src="./dist/main.js"></script>
 </body>

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -25,6 +25,10 @@ export function setup() {
   const heldYes = document.getElementById('held-yes') as HTMLInputElement;
   const heldNo = document.getElementById('held-no') as HTMLInputElement;
 
+  if (!commitYes || !commitNo || !heldYes || !heldNo) {
+    return;
+  }
+
   // daily reset for commit
   const firstSetRaw = localStorage.getItem(COMMIT_TIME_KEY);
   if (firstSetRaw) {
@@ -103,6 +107,10 @@ export function setup() {
   heldNo.addEventListener('change', handleHeldChange);
 }
 
-document.addEventListener('DOMContentLoaded', setup);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setup);
+} else {
+  setup();
+}
 
 export { isSameDay }; // for testing


### PR DESCRIPTION
## Summary
- restyle commitment page with button-like yes/no choices
- add CSS for red/green outlined buttons that fill when selected
- ensure setup runs even if DOM loads before listeners are attached

## Testing
- `cd Commitment && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abdc4e7070832a9238d514cd3a78a1