### PR TITLE
Track held days and show success visualization

### DIFF
--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -43,6 +43,19 @@
       opacity: 0.5;
       cursor: not-allowed;
     }
+    #success-visual {
+      display: flex;
+      gap: 4px;
+      margin-top: 1rem;
+    }
+    .day {
+      width: 20px;
+      height: 20px;
+      border: 1px solid #ccc;
+    }
+    .day.success {
+      background-color: green;
+    }
   </style>
 </head>
 <body>
@@ -61,6 +74,7 @@
     <input type="checkbox" class="option" name="held" id="held-no" value="no">
     <label for="held-no" class="choice no">No</label>
   </div>
+  <div id="success-visual"></div>
   <script type="module" src="./dist/main.js"></script>
 </body>
 </html>

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -12,7 +12,8 @@ describe('Commitment UI', () => {
         <span>Held it:</span>
         <label><input type="checkbox" name="held" id="held-yes" value="yes"> Yes</label>
         <label><input type="checkbox" name="held" id="held-no" value="no"> No</label>
-      </div>`;
+      </div>
+      <div id="success-visual"></div>`;
     localStorage.clear();
     jest.useFakeTimers();
   });
@@ -79,5 +80,25 @@ describe('Commitment UI', () => {
     heldNo.dispatchEvent(new Event('change'));
     expect(heldYes.checked).toBe(false);
     expect(heldNo.checked).toBe(true);
+  });
+
+  it('records held days on reset', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    localStorage.setItem('commitFirstSetAt', String(yesterday.getTime()));
+    localStorage.setItem('heldToggle', 'true');
+    setup();
+    const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
+    expect(successes).toContain(yesterday.toISOString().split('T')[0]);
+    expect(localStorage.getItem('heldToggle')).toBeNull();
+  });
+
+  it('renders success visualization', () => {
+    const todayStr = new Date().toISOString().split('T')[0];
+    localStorage.setItem('heldSuccessDates', JSON.stringify([todayStr]));
+    setup();
+    const squares = document.querySelectorAll('#success-visual .day');
+    expect(squares.length).toBe(7);
+    expect(squares[squares.length - 1].classList.contains('success')).toBe(true);
   });
 });

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -1,7 +1,9 @@
 const COMMIT_KEY = 'commitToggle';
 const COMMIT_TIME_KEY = 'commitFirstSetAt';
 const HELD_KEY = 'heldToggle';
+const HELD_SUCCESS_KEY = 'heldSuccessDates';
 const LOCK_DURATION_MS = 30 * 1000;
+const VISUAL_DAYS = 7;
 
 function isSameDay(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() &&
@@ -19,11 +21,27 @@ function scheduleLock(firstSetAt: number, inputs: HTMLInputElement[]) {
   }
 }
 
+function renderSuccesses(container: HTMLElement, dates: string[]) {
+  const today = new Date();
+  for (let i = VISUAL_DAYS - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    const dateStr = d.toISOString().split('T')[0];
+    const square = document.createElement('div');
+    square.className = 'day';
+    if (dates.includes(dateStr)) {
+      square.classList.add('success');
+    }
+    container.appendChild(square);
+  }
+}
+
 export function setup() {
   const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
   const commitNo = document.getElementById('commit-no') as HTMLInputElement;
   const heldYes = document.getElementById('held-yes') as HTMLInputElement;
   const heldNo = document.getElementById('held-no') as HTMLInputElement;
+  const successContainer = document.getElementById('success-visual');
 
   if (!commitYes || !commitNo || !heldYes || !heldNo) {
     return;
@@ -34,8 +52,17 @@ export function setup() {
   if (firstSetRaw) {
     const firstSetAt = parseInt(firstSetRaw, 10);
     if (!isSameDay(new Date(firstSetAt), new Date())) {
+      if (localStorage.getItem(HELD_KEY) === 'true') {
+        const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
+        const dateStr = new Date(firstSetAt).toISOString().split('T')[0];
+        if (!successes.includes(dateStr)) {
+          successes.push(dateStr);
+          localStorage.setItem(HELD_SUCCESS_KEY, JSON.stringify(successes));
+        }
+      }
       localStorage.removeItem(COMMIT_KEY);
       localStorage.removeItem(COMMIT_TIME_KEY);
+      localStorage.removeItem(HELD_KEY);
     }
   }
 
@@ -57,6 +84,11 @@ export function setup() {
     } else {
       heldNo.checked = true;
     }
+  }
+
+  if (successContainer) {
+    const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
+    renderSuccesses(successContainer, successes);
   }
 
   const handleCommitChange = (ev: Event) => {


### PR DESCRIPTION
## Summary
- record successful commitment days when daily reset occurs and clear the previous day's state
- render a week-long grid of green squares for successful days
- test coverage for storing held dates and success visualization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca6a62054832a9bd997bb29e633c9