### PR TITLE
feat: add admin data clear button

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -216,8 +216,16 @@ export function setup() {
             adjustDay(-1);
             location.reload();
         });
+        const clearBtn = document.createElement('button');
+        clearBtn.id = 'admin-clear-data';
+        clearBtn.textContent = 'Clear Data';
+        clearBtn.addEventListener('click', () => {
+            localStorage.clear();
+            location.reload();
+        });
         adminDiv.appendChild(prevBtn);
         adminDiv.appendChild(nextBtn);
+        adminDiv.appendChild(clearBtn);
         document.body.appendChild(adminDiv);
     }
 }

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -157,6 +157,24 @@ describe('Commitment UI', () => {
     window.history.pushState({}, '', '/?admin=true');
     setup();
     expect(document.getElementById('admin-next-day')).not.toBeNull();
+    expect(document.getElementById('admin-clear-data')).not.toBeNull();
+  });
+
+  it('clears data with admin clear button', () => {
+    window.history.pushState({}, '', '/?admin=true');
+    localStorage.setItem('commitToggle', 'true');
+    const originalLocation = window.location;
+    const reloadSpy = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, reload: reloadSpy },
+      configurable: true,
+    });
+    setup();
+    const clearBtn = document.getElementById('admin-clear-data') as HTMLButtonElement;
+    clearBtn.click();
+    expect(localStorage.getItem('commitToggle')).toBeNull();
+    expect(reloadSpy).toHaveBeenCalled();
+    Object.defineProperty(window, 'location', { value: originalLocation });
   });
 
   it('adjusts day offset', () => {

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -228,8 +228,16 @@ export function setup() {
       adjustDay(-1);
       location.reload();
     });
+    const clearBtn = document.createElement('button');
+    clearBtn.id = 'admin-clear-data';
+    clearBtn.textContent = 'Clear Data';
+    clearBtn.addEventListener('click', () => {
+      localStorage.clear();
+      location.reload();
+    });
     adminDiv.appendChild(prevBtn);
     adminDiv.appendChild(nextBtn);
+    adminDiv.appendChild(clearBtn);
     document.body.appendChild(adminDiv);
   }
 }


### PR DESCRIPTION
## Summary
- add admin-only Clear Data button to wipe stored commitment info
- test new clear data control and existing admin buttons

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0ddc7e984832a8944c193073c22cd