### PR TITLE
Display on-screen prompt for held commitment

### DIFF
--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -59,6 +59,13 @@
     .day.failure {
       background-color: red;
     }
+    .notice {
+      background-color: #ffeb3b;
+      border: 2px solid #fbc02d;
+      padding: 1rem;
+      margin: 1rem 0;
+      font-weight: bold;
+    }
   </style>
 </head>
 <body>
@@ -77,6 +84,7 @@
     <input type="checkbox" class="option" name="held" id="held-no" value="no">
     <label for="held-no" class="choice no">No</label>
   </div>
+  <div id="held-prompt" class="notice" hidden></div>
   <div id="success-visual"></div>
   <script type="module" src="./dist/main.js"></script>
 </body>

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -13,6 +13,7 @@ describe('Commitment UI', () => {
         <label><input type="checkbox" name="held" id="held-yes" value="yes"> Yes</label>
         <label><input type="checkbox" name="held" id="held-no" value="no"> No</label>
       </div>
+      <div id="held-prompt" hidden></div>
       <div id="success-visual"></div>`;
     localStorage.clear();
     jest.useFakeTimers();
@@ -109,9 +110,10 @@ describe('Commitment UI', () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     localStorage.setItem('commitFirstSetAt', String(yesterday.getTime()));
-    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
     setup();
-    expect(alertSpy).toHaveBeenCalledWith('Please record whether you held your commitment yesterday.');
+    const prompt = document.getElementById('held-prompt') as HTMLElement;
+    expect(prompt.hidden).toBe(false);
+    expect(prompt.textContent).toBe('Please record whether you held your commitment yesterday.');
     const heldYes = document.getElementById('held-yes') as HTMLInputElement;
     heldYes.checked = true;
     heldYes.dispatchEvent(new Event('change'));
@@ -120,7 +122,7 @@ describe('Commitment UI', () => {
     expect(localStorage.getItem('heldToggle')).toBeNull();
     const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
     expect(commitYes.disabled).toBe(false);
-    alertSpy.mockRestore();
+    expect(prompt.hidden).toBe(true);
   });
 
   it('warns and clears after multiple days of inactivity', () => {

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -64,6 +64,7 @@ export function setup() {
   const commitNo = document.getElementById('commit-no') as HTMLInputElement;
   const heldYes = document.getElementById('held-yes') as HTMLInputElement;
   const heldNo = document.getElementById('held-no') as HTMLInputElement;
+  const heldPrompt = document.getElementById('held-prompt') as HTMLElement | null;
   const successContainer = document.getElementById('success-visual');
 
   if (!commitYes || !commitNo || !heldYes || !heldNo) {
@@ -98,6 +99,10 @@ export function setup() {
     localStorage.removeItem(COMMIT_KEY);
     localStorage.removeItem(COMMIT_TIME_KEY);
     localStorage.removeItem(HELD_KEY);
+    if (heldPrompt) {
+      heldPrompt.textContent = '';
+      heldPrompt.hidden = true;
+    }
   };
 
   let awaitingHeld = false;
@@ -113,7 +118,10 @@ export function setup() {
       const held = localStorage.getItem(HELD_KEY);
       if (held === null) {
         awaitingHeld = true;
-        alert('Please record whether you held your commitment yesterday.');
+        if (heldPrompt) {
+          heldPrompt.textContent = 'Please record whether you held your commitment yesterday.';
+          heldPrompt.hidden = false;
+        }
       } else {
         if (held === 'true') {
           recordSuccess(firstSetAt);


### PR DESCRIPTION
## Summary
- Replace alert prompt with on-page notice prompting for yesterday's held status
- Add bright yellow notice styling and container in index.html
- Update tests to verify inline prompt visibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0df6e1684832aa994df9ea5c1928e