### PR TITLE
Implement 4am day change in commitment app

### DIFF
--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -85,31 +85,31 @@ describe('Commitment UI', () => {
   });
 
   it('records held days on reset', () => {
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    localStorage.setItem('commitFirstSetAt', String(yesterday.getTime()));
+    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
+    const commitTime = new Date('2023-01-01T22:00:00Z');
+    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
     localStorage.setItem('heldToggle', 'true');
     setup();
     const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
-    expect(successes).toContain(yesterday.toISOString().split('T')[0]);
+    expect(successes).toContain(commitTime.toISOString().split('T')[0]);
     expect(localStorage.getItem('heldToggle')).toBeNull();
   });
 
   it('records failed days on reset', () => {
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    localStorage.setItem('commitFirstSetAt', String(yesterday.getTime()));
+    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
+    const commitTime = new Date('2023-01-01T22:00:00Z');
+    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
     localStorage.setItem('heldToggle', 'false');
     setup();
     const failures = JSON.parse(localStorage.getItem('heldFailureDates') || '[]');
-    expect(failures).toContain(yesterday.toISOString().split('T')[0]);
+    expect(failures).toContain(commitTime.toISOString().split('T')[0]);
     expect(localStorage.getItem('heldToggle')).toBeNull();
   });
 
   it('prompts for held selection when missing from previous day', () => {
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    localStorage.setItem('commitFirstSetAt', String(yesterday.getTime()));
+    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
+    const commitTime = new Date('2023-01-01T22:00:00Z');
+    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
     setup();
     const prompt = document.getElementById('held-prompt') as HTMLElement;
     expect(prompt.hidden).toBe(false);
@@ -118,7 +118,7 @@ describe('Commitment UI', () => {
     heldYes.checked = true;
     heldYes.dispatchEvent(new Event('change'));
     const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
-    expect(successes).toContain(yesterday.toISOString().split('T')[0]);
+    expect(successes).toContain(commitTime.toISOString().split('T')[0]);
     expect(localStorage.getItem('heldToggle')).toBeNull();
     const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
     expect(commitYes.disabled).toBe(false);
@@ -126,9 +126,9 @@ describe('Commitment UI', () => {
   });
 
   it('warns and clears after multiple days of inactivity', () => {
-    const twoDaysAgo = new Date();
-    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
-    localStorage.setItem('commitFirstSetAt', String(twoDaysAgo.getTime()));
+    jest.setSystemTime(new Date('2023-01-03T05:00:00Z'));
+    const commitTime = new Date('2023-01-01T22:00:00Z');
+    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
     localStorage.setItem('commitToggle', 'true');
     const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
     setup();

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -7,6 +7,7 @@ const LOCK_DURATION_MS = 30 * 1000;
 const VISUAL_DAYS = 7;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const ADMIN_OFFSET_KEY = 'adminDayOffset';
+const DAY_CUTOFF_HOUR = 4;
 
 function isSameDay(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() &&
@@ -24,6 +25,12 @@ function currentTime(): number {
 
 function currentDate(): Date {
   return new Date(currentTime());
+}
+
+function getAppDay(date: Date): number {
+  const adjusted = new Date(date);
+  adjusted.setHours(adjusted.getHours() - DAY_CUTOFF_HOUR, 0, 0, 0);
+  return Math.floor(adjusted.getTime() / DAY_MS);
 }
 
 function scheduleLock(firstSetAt: number, inputs: HTMLInputElement[]) {
@@ -113,7 +120,7 @@ export function setup() {
     const firstSetAt = parseInt(firstSetRaw, 10);
     const firstDate = new Date(firstSetAt);
     const now = currentDate();
-    const diffDays = Math.floor((now.getTime() - firstDate.getTime()) / DAY_MS);
+    const diffDays = getAppDay(now) - getAppDay(firstDate);
     if (diffDays === 1) {
       const held = localStorage.getItem(HELD_KEY);
       if (held === null) {


### PR DESCRIPTION
## Summary
- treat a new day as starting at 4am and compute day differences using that cutoff
- update daily reset logic accordingly and add tests around the cutoff

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b305657fd8832abc4f2b91f1756fa9