### PR TITLE
Highlight current day in progress tracker

### DIFF
--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -59,6 +59,9 @@
     .day.failure {
       background-color: red;
     }
+    .day.current {
+      outline: 2px solid yellow;
+    }
     .notice {
       background-color: #ffeb3b;
       border: 2px solid #fbc02d;

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -155,6 +155,13 @@ describe('Commitment UI', () => {
     expect(squares[squares.length - 1].classList.contains('failure')).toBe(true);
   });
 
+  it('highlights the current day', () => {
+    setup();
+    const squares = document.querySelectorAll('#success-visual .day');
+    expect(squares.length).toBe(7);
+    expect(squares[squares.length - 1].classList.contains('current')).toBe(true);
+  });
+
   it('shows admin controls when admin query param present', () => {
     window.history.pushState({}, '', '/?admin=true');
     setup();

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -44,6 +44,9 @@ function renderSuccesses(container: HTMLElement, successes: string[], failures: 
     const dateStr = d.toISOString().split('T')[0];
     const square = document.createElement('div');
     square.className = 'day';
+    if (i === 0) {
+      square.classList.add('current');
+    }
     if (successes.includes(dateStr)) {
       square.classList.add('success');
     } else if (failures.includes(dateStr)) {


### PR DESCRIPTION
## Summary
- Add `current` class to today's square in commitment visual
- Style current day square with yellow outline
- Test for presence of current day highlight

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b305a21cc0832ab8952136d51d1f0c