### PR TITLE
Persist StreakTracker calendar state

### DIFF
--- a/StreakTracker/dist/main.js
+++ b/StreakTracker/dist/main.js
@@ -18,24 +18,37 @@ export function setup() {
     if (!calendar) {
         return;
     }
-    const cells = generateCalendar(now.getFullYear(), now.getMonth());
+    const year = now.getFullYear();
+    const month = now.getMonth();
+    const cells = generateCalendar(year, month);
     cells.forEach((value) => {
         const cell = document.createElement('div');
         cell.className = 'day';
         if (value !== null) {
             cell.textContent = String(value);
+            const dateKey = `${year}-${month + 1}-${value}`;
+            let state = Number(localStorage.getItem(dateKey)) || 0;
+            const applyState = (s) => {
+                cell.classList.remove('red', 'green');
+                if (s === 1) {
+                    cell.classList.add('red');
+                }
+                else if (s === 2) {
+                    cell.classList.add('green');
+                }
+            };
+            applyState(state);
+            cell.addEventListener('click', () => {
+                state = (state + 1) % 3;
+                applyState(state);
+                if (state === 0) {
+                    localStorage.removeItem(dateKey);
+                }
+                else {
+                    localStorage.setItem(dateKey, String(state));
+                }
+            });
         }
-        let state = 0;
-        cell.addEventListener('click', () => {
-            state = (state + 1) % 3;
-            cell.classList.remove('red', 'green');
-            if (state === 1) {
-                cell.classList.add('red');
-            }
-            else if (state === 2) {
-                cell.classList.add('green');
-            }
-        });
         calendar.appendChild(cell);
     });
 }

--- a/StreakTracker/src/main.test.ts
+++ b/StreakTracker/src/main.test.ts
@@ -1,7 +1,26 @@
-import { generateCalendar } from './main';
+import { generateCalendar, setup } from './main';
 
 test('generateCalendar has 42 cells and correct day count', () => {
   const cells = generateCalendar(2023, 0); // January 2023
   expect(cells.length).toBe(42);
   expect(cells.filter((d) => d !== null).length).toBe(31);
+});
+
+test('clicking a day saves and restores its state', () => {
+  document.body.innerHTML = '<h1 id="month-label"></h1><div id="calendar"></div>';
+  localStorage.clear();
+  setup();
+  const cell = Array.from(document.querySelectorAll('.day')).find(
+    (c) => c.textContent === '1'
+  ) as HTMLElement;
+  cell.dispatchEvent(new Event('click'));
+  const now = new Date();
+  const key = `${now.getFullYear()}-${now.getMonth() + 1}-1`;
+  expect(localStorage.getItem(key)).toBe('1');
+  document.body.innerHTML = '<h1 id="month-label"></h1><div id="calendar"></div>';
+  setup();
+  const cell2 = Array.from(document.querySelectorAll('.day')).find(
+    (c) => c.textContent === '1'
+  ) as HTMLElement;
+  expect(cell2.classList.contains('red')).toBe(true);
 });

--- a/StreakTracker/src/main.ts
+++ b/StreakTracker/src/main.ts
@@ -19,23 +19,35 @@ export function setup() {
   if (!calendar) {
     return;
   }
-  const cells = generateCalendar(now.getFullYear(), now.getMonth());
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const cells = generateCalendar(year, month);
   cells.forEach((value) => {
     const cell = document.createElement('div');
     cell.className = 'day';
     if (value !== null) {
       cell.textContent = String(value);
+      const dateKey = `${year}-${month + 1}-${value}`;
+      let state = Number(localStorage.getItem(dateKey)) || 0;
+      const applyState = (s: number) => {
+        cell.classList.remove('red', 'green');
+        if (s === 1) {
+          cell.classList.add('red');
+        } else if (s === 2) {
+          cell.classList.add('green');
+        }
+      };
+      applyState(state);
+      cell.addEventListener('click', () => {
+        state = (state + 1) % 3;
+        applyState(state);
+        if (state === 0) {
+          localStorage.removeItem(dateKey);
+        } else {
+          localStorage.setItem(dateKey, String(state));
+        }
+      });
     }
-    let state = 0;
-    cell.addEventListener('click', () => {
-      state = (state + 1) % 3;
-      cell.classList.remove('red', 'green');
-      if (state === 1) {
-        cell.classList.add('red');
-      } else if (state === 2) {
-        cell.classList.add('green');
-      }
-    });
     calendar.appendChild(cell);
   });
 }


### PR DESCRIPTION
## Summary
- store and restore calendar day colors using localStorage
- add test for calendar state persistence
- refactor state application helper to take explicit state argument

## Testing
- `npm test`
- `npm run lint`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68b3b5f7d7e8832ab48dfbc20c8efac5