### PR TITLE
Show previous months in StreakTracker

### DIFF
--- a/StreakTracker/index.html
+++ b/StreakTracker/index.html
@@ -9,10 +9,11 @@
       font-family: Arial, sans-serif;
       padding: 1rem;
     }
-    #calendar {
+    .calendar {
       display: grid;
       grid-template-columns: repeat(7, 1fr);
       gap: 2px;
+      margin-bottom: 1rem;
     }
     .day {
       border: 1px solid #ccc;
@@ -28,8 +29,7 @@
   </style>
 </head>
 <body>
-  <h1 id="month-label"></h1>
-  <div id="calendar"></div>
+  <div id="calendars"></div>
   <script type="module" src="./dist/main.js"></script>
 </body>
 </html>

--- a/StreakTracker/src/main.test.ts
+++ b/StreakTracker/src/main.test.ts
@@ -7,7 +7,7 @@ test('generateCalendar has 42 cells and correct day count', () => {
 });
 
 test('clicking a day saves and restores its state', () => {
-  document.body.innerHTML = '<h1 id="month-label"></h1><div id="calendar"></div>';
+  document.body.innerHTML = '<div id="calendars"></div>';
   localStorage.clear();
   setup();
   const cell = Array.from(document.querySelectorAll('.day')).find(
@@ -17,10 +17,35 @@ test('clicking a day saves and restores its state', () => {
   const now = new Date();
   const key = `${now.getFullYear()}-${now.getMonth() + 1}-1`;
   expect(localStorage.getItem(key)).toBe('1');
-  document.body.innerHTML = '<h1 id="month-label"></h1><div id="calendar"></div>';
+  document.body.innerHTML = '<div id="calendars"></div>';
   setup();
   const cell2 = Array.from(document.querySelectorAll('.day')).find(
     (c) => c.textContent === '1'
   ) as HTMLElement;
   expect(cell2.classList.contains('red')).toBe(true);
+});
+
+test('renders previous months below current month', () => {
+  document.body.innerHTML = '<div id="calendars"></div>';
+  localStorage.clear();
+  const now = new Date();
+  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const key = `${prev.getFullYear()}-${prev.getMonth() + 1}-1`;
+  localStorage.setItem(key, '1');
+  setup();
+  const headings = Array.from(document.querySelectorAll('h1')).map(
+    (h) => h.textContent
+  );
+  const currentLabel = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    1
+  ).toLocaleString('default', { month: 'long', year: 'numeric' });
+  const prevLabel = new Date(
+    prev.getFullYear(),
+    prev.getMonth(),
+    1
+  ).toLocaleString('default', { month: 'long', year: 'numeric' });
+  expect(headings[0]).toBe(currentLabel);
+  expect(headings[1]).toBe(prevLabel);
 });

--- a/StreakTracker/src/main.ts
+++ b/StreakTracker/src/main.ts
@@ -8,47 +8,79 @@ export function generateCalendar(year: number, month: number): (number | null)[]
   return cells;
 }
 
-export function setup() {
-  const now = new Date();
-  const label = document.getElementById('month-label');
-  if (label) {
-    const monthName = now.toLocaleString('default', { month: 'long' });
-    label.textContent = `${monthName} ${now.getFullYear()}`;
+function getStoredMonths(now: Date): { year: number; month: number }[] {
+  const months = new Set<string>();
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && /^\d{4}-\d{1,2}-\d{1,2}$/.test(key)) {
+      const [y, m] = key.split('-').map(Number);
+      months.add(`${y}-${m}`);
+    }
   }
-  const calendar = document.getElementById('calendar');
-  if (!calendar) {
+  months.add(`${now.getFullYear()}-${now.getMonth() + 1}`);
+  return Array.from(months).map((str) => {
+    const [y, m] = str.split('-').map(Number);
+    return { year: y, month: m };
+  });
+}
+
+export function setup() {
+  const container = document.getElementById('calendars');
+  if (!container) {
     return;
   }
-  const year = now.getFullYear();
-  const month = now.getMonth();
-  const cells = generateCalendar(year, month);
-  cells.forEach((value) => {
-    const cell = document.createElement('div');
-    cell.className = 'day';
-    if (value !== null) {
-      cell.textContent = String(value);
-      const dateKey = `${year}-${month + 1}-${value}`;
-      let state = Number(localStorage.getItem(dateKey)) || 0;
-      const applyState = (s: number) => {
-        cell.classList.remove('red', 'green');
-        if (s === 1) {
-          cell.classList.add('red');
-        } else if (s === 2) {
-          cell.classList.add('green');
-        }
-      };
-      applyState(state);
-      cell.addEventListener('click', () => {
-        state = (state + 1) % 3;
-        applyState(state);
-        if (state === 0) {
-          localStorage.removeItem(dateKey);
-        } else {
-          localStorage.setItem(dateKey, String(state));
-        }
-      });
+  container.innerHTML = '';
+
+  const now = new Date();
+  const months = getStoredMonths(now).sort((a, b) => {
+    if (a.year === b.year) {
+      return b.month - a.month;
     }
-    calendar.appendChild(cell);
+    return b.year - a.year;
+  });
+
+  months.forEach(({ year, month }) => {
+    const section = document.createElement('section');
+    const label = document.createElement('h1');
+    const monthName = new Date(year, month - 1).toLocaleString('default', {
+      month: 'long',
+    });
+    label.textContent = `${monthName} ${year}`;
+    section.appendChild(label);
+
+    const calendar = document.createElement('div');
+    calendar.className = 'calendar';
+    const cells = generateCalendar(year, month - 1);
+    cells.forEach((value) => {
+      const cell = document.createElement('div');
+      cell.className = 'day';
+      if (value !== null) {
+        cell.textContent = String(value);
+        const dateKey = `${year}-${month}-${value}`;
+        let state = Number(localStorage.getItem(dateKey)) || 0;
+        const applyState = (s: number) => {
+          cell.classList.remove('red', 'green');
+          if (s === 1) {
+            cell.classList.add('red');
+          } else if (s === 2) {
+            cell.classList.add('green');
+          }
+        };
+        applyState(state);
+        cell.addEventListener('click', () => {
+          state = (state + 1) % 3;
+          applyState(state);
+          if (state === 0) {
+            localStorage.removeItem(dateKey);
+          } else {
+            localStorage.setItem(dateKey, String(state));
+          }
+        });
+      }
+      calendar.appendChild(cell);
+    });
+    section.appendChild(calendar);
+    container.appendChild(section);
   });
 }
 


### PR DESCRIPTION
## Summary
- render calendars for all months stored in localStorage so older months remain visible
- place the current month at the top and append previous months below
- adjust tests and HTML to support multiple calendar sections

## Testing
- `npm test --prefix StreakTracker`

------
https://chatgpt.com/codex/tasks/task_e_68b5a2200ecc832a99ebef3c14591e87