### PR TITLE
feat: add monthly streak statistics

### DIFF
--- a/StreakTracker/dist/main.js
+++ b/StreakTracker/dist/main.js
@@ -45,6 +45,36 @@ export function setup() {
         section.appendChild(label);
         const calendar = document.createElement('div');
         calendar.className = 'calendar';
+        const stats = document.createElement('p');
+        stats.className = 'stats';
+        const updateStats = () => {
+            const daysInMonth = new Date(year, month, 0).getDate();
+            let daysPassed = 0;
+            if (year === now.getFullYear() && month === now.getMonth() + 1) {
+                daysPassed = now.getDate();
+            }
+            else if (year < now.getFullYear() ||
+                (year === now.getFullYear() && month < now.getMonth() + 1)) {
+                daysPassed = daysInMonth;
+            }
+            let greenDays = 0;
+            let longestStreak = 0;
+            let currentStreak = 0;
+            for (let day = 1; day <= daysPassed; day++) {
+                const state = Number(localStorage.getItem(`${year}-${month}-${day}`));
+                if (state === 2) {
+                    greenDays++;
+                    currentStreak++;
+                    if (currentStreak > longestStreak) {
+                        longestStreak = currentStreak;
+                    }
+                }
+                else {
+                    currentStreak = 0;
+                }
+            }
+            stats.textContent = `Green days: ${greenDays}/${daysPassed}, Longest green streak: ${longestStreak}`;
+        };
         const cells = generateCalendar(year, month - 1);
         cells.forEach((value) => {
             const cell = document.createElement('div');
@@ -72,12 +102,15 @@ export function setup() {
                     else {
                         localStorage.setItem(dateKey, String(state));
                     }
+                    updateStats();
                 });
             }
             calendar.appendChild(cell);
         });
         section.appendChild(calendar);
+        section.appendChild(stats);
         container.appendChild(section);
+        updateStats();
     });
 }
 if (document.readyState === 'loading') {

--- a/StreakTracker/src/main.test.ts
+++ b/StreakTracker/src/main.test.ts
@@ -49,3 +49,26 @@ test('renders previous months below current month', () => {
   expect(headings[0]).toBe(currentLabel);
   expect(headings[1]).toBe(prevLabel);
 });
+
+test('stats update with green days and longest streak', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2023-06-15'));
+  document.body.innerHTML = '<div id="calendars"></div>';
+  localStorage.clear();
+  setup();
+  const stats = document.querySelector('.stats') as HTMLElement;
+  expect(stats.textContent).toBe('Green days: 0/15, Longest green streak: 0');
+  const day1 = Array.from(document.querySelectorAll('.day')).find(
+    (c) => c.textContent === '1'
+  ) as HTMLElement;
+  day1.click();
+  day1.click();
+  expect(stats.textContent).toBe('Green days: 1/15, Longest green streak: 1');
+  const day2 = Array.from(document.querySelectorAll('.day')).find(
+    (c) => c.textContent === '2'
+  ) as HTMLElement;
+  day2.click();
+  day2.click();
+  expect(stats.textContent).toBe('Green days: 2/15, Longest green streak: 2');
+  jest.useRealTimers();
+});

--- a/StreakTracker/src/main.ts
+++ b/StreakTracker/src/main.ts
@@ -50,6 +50,36 @@ export function setup() {
 
     const calendar = document.createElement('div');
     calendar.className = 'calendar';
+    const stats = document.createElement('p');
+    stats.className = 'stats';
+    const updateStats = () => {
+      const daysInMonth = new Date(year, month, 0).getDate();
+      let daysPassed = 0;
+      if (year === now.getFullYear() && month === now.getMonth() + 1) {
+        daysPassed = now.getDate();
+      } else if (
+        year < now.getFullYear() ||
+        (year === now.getFullYear() && month < now.getMonth() + 1)
+      ) {
+        daysPassed = daysInMonth;
+      }
+      let greenDays = 0;
+      let longestStreak = 0;
+      let currentStreak = 0;
+      for (let day = 1; day <= daysPassed; day++) {
+        const state = Number(localStorage.getItem(`${year}-${month}-${day}`));
+        if (state === 2) {
+          greenDays++;
+          currentStreak++;
+          if (currentStreak > longestStreak) {
+            longestStreak = currentStreak;
+          }
+        } else {
+          currentStreak = 0;
+        }
+      }
+      stats.textContent = `Green days: ${greenDays}/${daysPassed}, Longest green streak: ${longestStreak}`;
+    };
     const cells = generateCalendar(year, month - 1);
     cells.forEach((value) => {
       const cell = document.createElement('div');
@@ -75,12 +105,15 @@ export function setup() {
           } else {
             localStorage.setItem(dateKey, String(state));
           }
+          updateStats();
         });
       }
       calendar.appendChild(cell);
     });
     section.appendChild(calendar);
+    section.appendChild(stats);
     container.appendChild(section);
+    updateStats();
   });
 }
 


### PR DESCRIPTION
## Summary
- track green-day ratio and longest streak for each calendar month
- update statistics whenever a day is toggled
- test stats update logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8831f3350832aa50cd5217852da65