### PR TITLE
Fix success visualization update after held selection

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -7,6 +7,7 @@ const LOCK_DURATION_MS = 30 * 1000;
 const VISUAL_DAYS = 7;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const ADMIN_OFFSET_KEY = 'adminDayOffset';
+const DAY_CUTOFF_HOUR = 4;
 function isSameDay(a, b) {
     return a.getFullYear() === b.getFullYear() &&
         a.getMonth() === b.getMonth() &&
@@ -20,6 +21,11 @@ function currentTime() {
 }
 function currentDate() {
     return new Date(currentTime());
+}
+function getAppDay(date) {
+    const adjusted = new Date(date);
+    adjusted.setHours(adjusted.getHours() - DAY_CUTOFF_HOUR, 0, 0, 0);
+    return Math.floor(adjusted.getTime() / DAY_MS);
 }
 function scheduleLock(firstSetAt, inputs) {
     const disableInputs = () => inputs.forEach(r => r.disabled = true);
@@ -104,7 +110,7 @@ export function setup() {
         const firstSetAt = parseInt(firstSetRaw, 10);
         const firstDate = new Date(firstSetAt);
         const now = currentDate();
-        const diffDays = Math.floor((now.getTime() - firstDate.getTime()) / DAY_MS);
+        const diffDays = getAppDay(now) - getAppDay(firstDate);
         if (diffDays === 1) {
             const held = localStorage.getItem(HELD_KEY);
             if (held === null) {
@@ -207,6 +213,12 @@ export function setup() {
             }
             resetSelections();
             awaitingHeld = false;
+            if (successContainer) {
+                successContainer.innerHTML = '';
+                const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
+                const failures = JSON.parse(localStorage.getItem(HELD_FAILURE_KEY) || '[]');
+                renderSuccesses(successContainer, successes, failures);
+            }
         }
     };
     heldYes.addEventListener('change', handleHeldChange);

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -110,6 +110,7 @@ describe('Commitment UI', () => {
     jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
     const commitTime = new Date('2023-01-01T22:00:00Z');
     localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+    localStorage.setItem('commitToggle', 'true');
     setup();
     const prompt = document.getElementById('held-prompt') as HTMLElement;
     expect(prompt.hidden).toBe(false);
@@ -123,6 +124,19 @@ describe('Commitment UI', () => {
     const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
     expect(commitYes.disabled).toBe(false);
     expect(prompt.hidden).toBe(true);
+  });
+
+  it('updates success visualization after recording held result', () => {
+    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
+    const commitTime = new Date('2023-01-01T22:00:00Z');
+    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+    localStorage.setItem('commitToggle', 'true');
+    setup();
+    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+    heldYes.checked = true;
+    heldYes.dispatchEvent(new Event('change'));
+    const squares = document.querySelectorAll('#success-visual .day');
+    expect(squares[squares.length - 2].classList.contains('success')).toBe(true);
   });
 
   it('warns and clears after multiple days of inactivity', () => {

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -224,6 +224,12 @@ export function setup() {
       }
       resetSelections();
       awaitingHeld = false;
+      if (successContainer) {
+        successContainer.innerHTML = '';
+        const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
+        const failures = JSON.parse(localStorage.getItem(HELD_FAILURE_KEY) || '[]');
+        renderSuccesses(successContainer, successes, failures);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- Re-render success grid after recording a held commitment so the UI updates without a refresh
- Add regression test for updating the success visualization when recording held status

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d86444c832aa8a6964bc5a5b723