### PR TITLE
Display dates under commitment streak boxes

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -43,6 +43,8 @@ function renderSuccesses(container, successes, failures) {
         const d = new Date(today);
         d.setDate(today.getDate() - i);
         const dateStr = d.toISOString().split('T')[0];
+        const wrapper = document.createElement('div');
+        wrapper.className = 'day-container';
         const square = document.createElement('div');
         square.className = 'day';
         if (i === 0) {
@@ -54,7 +56,12 @@ function renderSuccesses(container, successes, failures) {
         else if (failures.includes(dateStr)) {
             square.classList.add('failure');
         }
-        container.appendChild(square);
+        wrapper.appendChild(square);
+        const label = document.createElement('div');
+        label.className = 'day-date';
+        label.textContent = `${d.getMonth() + 1}/${d.getDate()}`;
+        wrapper.appendChild(label);
+        container.appendChild(wrapper);
     }
 }
 export function setup() {

--- a/Commitment/index.html
+++ b/Commitment/index.html
@@ -48,6 +48,11 @@
       gap: 4px;
       margin-top: 1rem;
     }
+    .day-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
     .day {
       width: 20px;
       height: 20px;
@@ -62,6 +67,10 @@
     .day.current {
       outline: 2px solid yellow;
       box-shadow: 0 0 8px 2px yellow;
+    }
+    .day-date {
+      font-size: 0.7rem;
+      margin-top: 2px;
     }
     .notice {
       background-color: #ffeb3b;

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -169,6 +169,15 @@ describe('Commitment UI', () => {
     expect(squares[squares.length - 1].classList.contains('failure')).toBe(true);
   });
 
+  it('shows dates under success visualization', () => {
+    setup();
+    const labels = document.querySelectorAll('#success-visual .day-date');
+    expect(labels.length).toBe(7);
+    const today = new Date();
+    const expected = `${today.getMonth() + 1}/${today.getDate()}`;
+    expect(labels[labels.length - 1].textContent).toBe(expected);
+  });
+
   it('highlights the current day', () => {
     setup();
     const squares = document.querySelectorAll('#success-visual .day');

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -49,6 +49,9 @@ function renderSuccesses(container: HTMLElement, successes: string[], failures: 
     const d = new Date(today);
     d.setDate(today.getDate() - i);
     const dateStr = d.toISOString().split('T')[0];
+    const wrapper = document.createElement('div');
+    wrapper.className = 'day-container';
+
     const square = document.createElement('div');
     square.className = 'day';
     if (i === 0) {
@@ -59,7 +62,14 @@ function renderSuccesses(container: HTMLElement, successes: string[], failures: 
     } else if (failures.includes(dateStr)) {
       square.classList.add('failure');
     }
-    container.appendChild(square);
+    wrapper.appendChild(square);
+
+    const label = document.createElement('div');
+    label.className = 'day-date';
+    label.textContent = `${d.getMonth() + 1}/${d.getDate()}`;
+    wrapper.appendChild(label);
+
+    container.appendChild(wrapper);
   }
 }
 


### PR DESCRIPTION
## Summary
- Show each tracked day with a square and its month/day label underneath
- Style commitment history items for vertical alignment and add date captions
- Test that seven date labels render with the correct current date

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bdf6e73ed4832a939a86b77adc7bd5