### PR TITLE
Fix held-day recording for early morning commitments

### DIFF
--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -126,6 +126,19 @@ describe('Commitment UI', () => {
     expect(prompt.hidden).toBe(true);
   });
 
+  it('records correct date for early morning commit when held is recorded next day', () => {
+    jest.setSystemTime(new Date('2023-01-01T05:00:00Z'));
+    const commitTime = new Date('2023-01-01T03:00:00Z');
+    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+    localStorage.setItem('commitToggle', 'true');
+    setup();
+    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+    heldYes.checked = true;
+    heldYes.dispatchEvent(new Event('change'));
+    const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
+    expect(successes).toContain('2022-12-31');
+  });
+
   it('updates success visualization after recording held result', () => {
     jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
     const commitTime = new Date('2023-01-01T22:00:00Z');

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -91,9 +91,15 @@ export function setup() {
     return;
   }
 
+  const appDateString = (time: number) => {
+    const day = getAppDay(new Date(time));
+    const d = new Date(day * DAY_MS);
+    return d.toISOString().split('T')[0];
+  };
+
   const recordSuccess = (firstSetAt: number) => {
     const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
-    const dateStr = new Date(firstSetAt).toISOString().split('T')[0];
+    const dateStr = appDateString(firstSetAt);
     if (!successes.includes(dateStr)) {
       successes.push(dateStr);
       localStorage.setItem(HELD_SUCCESS_KEY, JSON.stringify(successes));
@@ -102,7 +108,7 @@ export function setup() {
 
   const recordFailure = (firstSetAt: number) => {
     const failures = JSON.parse(localStorage.getItem(HELD_FAILURE_KEY) || '[]');
-    const dateStr = new Date(firstSetAt).toISOString().split('T')[0];
+    const dateStr = appDateString(firstSetAt);
     if (!failures.includes(dateStr)) {
       failures.push(dateStr);
       localStorage.setItem(HELD_FAILURE_KEY, JSON.stringify(failures));


### PR DESCRIPTION
## Summary
- use app day when recording held success/failure dates
- test early morning commit carried over to next day

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2bc452c64832aa6e4faeb55d11882