### PR TITLE
Fix held success date across timezones

### DIFF
--- a/Commitment/dist/main.js
+++ b/Commitment/dist/main.js
@@ -27,6 +27,11 @@ function getAppDay(date) {
     adjusted.setHours(adjusted.getHours() - DAY_CUTOFF_HOUR, 0, 0, 0);
     return Math.floor(adjusted.getTime() / DAY_MS);
 }
+function getDateKey(date) {
+    const d = new Date(date.getTime() - DAY_CUTOFF_HOUR * 60 * 60 * 1000);
+    d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+    return d.toISOString().split('T')[0];
+}
 function scheduleLock(firstSetAt, inputs) {
     const disableInputs = () => inputs.forEach(r => r.disabled = true);
     const remaining = LOCK_DURATION_MS - (currentTime() - firstSetAt);
@@ -42,7 +47,7 @@ function renderSuccesses(container, successes, failures) {
     for (let i = VISUAL_DAYS - 1; i >= 0; i--) {
         const d = new Date(today);
         d.setDate(today.getDate() - i);
-        const dateStr = d.toISOString().split('T')[0];
+        const dateStr = getDateKey(d);
         const wrapper = document.createElement('div');
         wrapper.className = 'day-container';
         const square = document.createElement('div');
@@ -81,7 +86,7 @@ export function setup() {
     }
     const recordSuccess = (firstSetAt) => {
         const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
-        const dateStr = new Date(firstSetAt).toISOString().split('T')[0];
+        const dateStr = getDateKey(new Date(firstSetAt));
         if (!successes.includes(dateStr)) {
             successes.push(dateStr);
             localStorage.setItem(HELD_SUCCESS_KEY, JSON.stringify(successes));
@@ -89,7 +94,7 @@ export function setup() {
     };
     const recordFailure = (firstSetAt) => {
         const failures = JSON.parse(localStorage.getItem(HELD_FAILURE_KEY) || '[]');
-        const dateStr = new Date(firstSetAt).toISOString().split('T')[0];
+        const dateStr = getDateKey(new Date(firstSetAt));
         if (!failures.includes(dateStr)) {
             failures.push(dateStr);
             localStorage.setItem(HELD_FAILURE_KEY, JSON.stringify(failures));

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -139,6 +139,24 @@ describe('Commitment UI', () => {
     expect(squares[squares.length - 2].classList.contains('success')).toBe(true);
   });
 
+  it('records success for the previous local day when crossing UTC midnight', () => {
+    const realOffset = Date.prototype.getTimezoneOffset;
+    Date.prototype.getTimezoneOffset = () => 300;
+    jest.setSystemTime(new Date('2023-01-02T13:00:00Z'));
+    const commitTime = new Date('2023-01-02T03:00:00Z');
+    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+    localStorage.setItem('commitToggle', 'true');
+    setup();
+    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+    heldYes.checked = true;
+    heldYes.dispatchEvent(new Event('change'));
+    const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
+    expect(successes).toContain('2023-01-01');
+    const squares = document.querySelectorAll('#success-visual .day');
+    expect(squares[squares.length - 2].classList.contains('success')).toBe(true);
+    Date.prototype.getTimezoneOffset = realOffset;
+  });
+
   it('warns and clears after multiple days of inactivity', () => {
     jest.setSystemTime(new Date('2023-01-03T05:00:00Z'));
     const commitTime = new Date('2023-01-01T22:00:00Z');

--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -33,6 +33,12 @@ function getAppDay(date: Date): number {
   return Math.floor(adjusted.getTime() / DAY_MS);
 }
 
+function getDateKey(date: Date): string {
+  const d = new Date(date.getTime() - DAY_CUTOFF_HOUR * 60 * 60 * 1000);
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().split('T')[0];
+}
+
 function scheduleLock(firstSetAt: number, inputs: HTMLInputElement[]) {
   const disableInputs = () => inputs.forEach(r => r.disabled = true);
   const remaining = LOCK_DURATION_MS - (currentTime() - firstSetAt);
@@ -48,7 +54,7 @@ function renderSuccesses(container: HTMLElement, successes: string[], failures: 
   for (let i = VISUAL_DAYS - 1; i >= 0; i--) {
     const d = new Date(today);
     d.setDate(today.getDate() - i);
-    const dateStr = d.toISOString().split('T')[0];
+    const dateStr = getDateKey(d);
     const wrapper = document.createElement('div');
     wrapper.className = 'day-container';
 
@@ -93,7 +99,7 @@ export function setup() {
 
   const recordSuccess = (firstSetAt: number) => {
     const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
-    const dateStr = new Date(firstSetAt).toISOString().split('T')[0];
+    const dateStr = getDateKey(new Date(firstSetAt));
     if (!successes.includes(dateStr)) {
       successes.push(dateStr);
       localStorage.setItem(HELD_SUCCESS_KEY, JSON.stringify(successes));
@@ -102,7 +108,7 @@ export function setup() {
 
   const recordFailure = (firstSetAt: number) => {
     const failures = JSON.parse(localStorage.getItem(HELD_FAILURE_KEY) || '[]');
-    const dateStr = new Date(firstSetAt).toISOString().split('T')[0];
+    const dateStr = getDateKey(new Date(firstSetAt));
     if (!failures.includes(dateStr)) {
       failures.push(dateStr);
       localStorage.setItem(HELD_FAILURE_KEY, JSON.stringify(failures));


### PR DESCRIPTION
## Summary
- Ensure held successes/failures are recorded using local day
- Re-render success squares with timezone-aware dates
- Add regression test for timezone crossing at midnight

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2bccc1284832aab206b780638d8d0