### PR TITLE
feat: add blue day option to streak tracker

### DIFF
--- a/StreakTracker/dist/main.js
+++ b/StreakTracker/dist/main.js
@@ -84,17 +84,20 @@ export function setup() {
                 const dateKey = `${year}-${month}-${value}`;
                 let state = Number(localStorage.getItem(dateKey)) || 0;
                 const applyState = (s) => {
-                    cell.classList.remove('red', 'green');
+                    cell.classList.remove('red', 'green', 'blue');
                     if (s === 1) {
                         cell.classList.add('red');
                     }
                     else if (s === 2) {
                         cell.classList.add('green');
                     }
+                    else if (s === 3) {
+                        cell.classList.add('blue');
+                    }
                 };
                 applyState(state);
                 cell.addEventListener('click', () => {
-                    state = (state + 1) % 3;
+                    state = (state + 1) % 4;
                     applyState(state);
                     if (state === 0) {
                         localStorage.removeItem(dateKey);

--- a/StreakTracker/index.html
+++ b/StreakTracker/index.html
@@ -26,6 +26,9 @@
     .day.green {
       background-color: green;
     }
+    .day.blue {
+      background-color: blue;
+    }
   </style>
 </head>
 <body>

--- a/StreakTracker/src/main.test.ts
+++ b/StreakTracker/src/main.test.ts
@@ -25,6 +25,27 @@ test('clicking a day saves and restores its state', () => {
   expect(cell2.classList.contains('red')).toBe(true);
 });
 
+test('third click sets day to blue and persists state', () => {
+  document.body.innerHTML = '<div id="calendars"></div>';
+  localStorage.clear();
+  setup();
+  const cell = Array.from(document.querySelectorAll('.day')).find(
+    (c) => c.textContent === '1'
+  ) as HTMLElement;
+  cell.click();
+  cell.click();
+  cell.click();
+  const now = new Date();
+  const key = `${now.getFullYear()}-${now.getMonth() + 1}-1`;
+  expect(localStorage.getItem(key)).toBe('3');
+  document.body.innerHTML = '<div id="calendars"></div>';
+  setup();
+  const cell2 = Array.from(document.querySelectorAll('.day')).find(
+    (c) => c.textContent === '1'
+  ) as HTMLElement;
+  expect(cell2.classList.contains('blue')).toBe(true);
+});
+
 test('renders previous months below current month', () => {
   document.body.innerHTML = '<div id="calendars"></div>';
   localStorage.clear();

--- a/StreakTracker/src/main.ts
+++ b/StreakTracker/src/main.ts
@@ -89,16 +89,18 @@ export function setup() {
         const dateKey = `${year}-${month}-${value}`;
         let state = Number(localStorage.getItem(dateKey)) || 0;
         const applyState = (s: number) => {
-          cell.classList.remove('red', 'green');
+          cell.classList.remove('red', 'green', 'blue');
           if (s === 1) {
             cell.classList.add('red');
           } else if (s === 2) {
             cell.classList.add('green');
+          } else if (s === 3) {
+            cell.classList.add('blue');
           }
         };
         applyState(state);
         cell.addEventListener('click', () => {
-          state = (state + 1) % 3;
+          state = (state + 1) % 4;
           applyState(state);
           if (state === 0) {
             localStorage.removeItem(dateKey);


### PR DESCRIPTION
## Summary
- allow marking days in blue in the streak tracker
- add CSS for blue days and adjust state cycling
- cover new blue state with tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c77e9c2d58832a8d142279d537b871