### PR TITLE
Add multi-color stats and lighten blue day styling

### DIFF
--- a/StreakTracker/index.html
+++ b/StreakTracker/index.html
@@ -27,7 +27,7 @@
       background-color: green;
     }
     .day.blue {
-      background-color: blue;
+      background-color: #87cefa;
     }
   </style>
 </head>

--- a/StreakTracker/src/main.test.ts
+++ b/StreakTracker/src/main.test.ts
@@ -71,25 +71,92 @@ test('renders previous months below current month', () => {
   expect(headings[1]).toBe(prevLabel);
 });
 
-test('stats update with green days and longest streak', () => {
+test('stats update for all colors and streaks', () => {
   jest.useFakeTimers();
   jest.setSystemTime(new Date('2023-06-15'));
   document.body.innerHTML = '<div id="calendars"></div>';
   localStorage.clear();
   setup();
   const stats = document.querySelector('.stats') as HTMLElement;
-  expect(stats.textContent).toBe('Green days: 0/15, Longest green streak: 0');
+  const expectStats = (lines: string[]) => {
+    expect(stats.innerHTML).toBe(lines.join('<br>'));
+  };
+  expectStats([
+    'Green days: 0/15, Longest green streak: 0',
+    'Red days: 0/15, Longest red streak: 0',
+    'Blue days: 0/15, Longest blue streak: 0',
+    'Longest green or blue streak: 0',
+  ]);
   const day1 = Array.from(document.querySelectorAll('.day')).find(
     (c) => c.textContent === '1'
   ) as HTMLElement;
   day1.click();
+  expectStats([
+    'Green days: 0/15, Longest green streak: 0',
+    'Red days: 1/15, Longest red streak: 1',
+    'Blue days: 0/15, Longest blue streak: 0',
+    'Longest green or blue streak: 0',
+  ]);
   day1.click();
-  expect(stats.textContent).toBe('Green days: 1/15, Longest green streak: 1');
-  const day2 = Array.from(document.querySelectorAll('.day')).find(
-    (c) => c.textContent === '2'
-  ) as HTMLElement;
-  day2.click();
-  day2.click();
-  expect(stats.textContent).toBe('Green days: 2/15, Longest green streak: 2');
+  expectStats([
+    'Green days: 1/15, Longest green streak: 1',
+    'Red days: 0/15, Longest red streak: 0',
+    'Blue days: 0/15, Longest blue streak: 0',
+    'Longest green or blue streak: 1',
+  ]);
+  day1.click();
+  expectStats([
+    'Green days: 0/15, Longest green streak: 0',
+    'Red days: 0/15, Longest red streak: 0',
+    'Blue days: 1/15, Longest blue streak: 1',
+    'Longest green or blue streak: 1',
+  ]);
+  jest.useRealTimers();
+});
+
+test('longest green or blue streak spans both colors', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2023-06-15'));
+  document.body.innerHTML = '<div id="calendars"></div>';
+  localStorage.clear();
+  setup();
+  const stats = document.querySelector('.stats') as HTMLElement;
+  const getCell = (day: string) =>
+    Array.from(document.querySelectorAll('.day')).find(
+      (c) => c.textContent === day
+    ) as HTMLElement;
+  const getState = (cell: HTMLElement) => {
+    if (cell.classList.contains('red')) {
+      return 1;
+    }
+    if (cell.classList.contains('green')) {
+      return 2;
+    }
+    if (cell.classList.contains('blue')) {
+      return 3;
+    }
+    return 0;
+  };
+  const setState = (cell: HTMLElement, state: number) => {
+    for (let i = 0; i < 4; i++) {
+      if (getState(cell) === state) {
+        return;
+      }
+      cell.click();
+    }
+    throw new Error('Unable to reach desired state');
+  };
+  setState(getCell('1'), 2);
+  setState(getCell('2'), 2);
+  setState(getCell('3'), 3);
+  setState(getCell('4'), 2);
+  expect(stats.innerHTML).toBe(
+    [
+      'Green days: 3/15, Longest green streak: 2',
+      'Red days: 0/15, Longest red streak: 0',
+      'Blue days: 1/15, Longest blue streak: 1',
+      'Longest green or blue streak: 4',
+    ].join('<br>')
+  );
   jest.useRealTimers();
 });

--- a/StreakTracker/src/main.ts
+++ b/StreakTracker/src/main.ts
@@ -63,22 +63,71 @@ export function setup() {
       ) {
         daysPassed = daysInMonth;
       }
-      let greenDays = 0;
-      let longestStreak = 0;
-      let currentStreak = 0;
+      const colorCounts = {
+        red: 0,
+        green: 0,
+        blue: 0,
+      };
+      const currentStreaks = {
+        red: 0,
+        green: 0,
+        blue: 0,
+      };
+      const longestStreaks = {
+        red: 0,
+        green: 0,
+        blue: 0,
+      };
+      let currentGreenBlueStreak = 0;
+      let longestGreenBlueStreak = 0;
       for (let day = 1; day <= daysPassed; day++) {
         const state = Number(localStorage.getItem(`${year}-${month}-${day}`));
-        if (state === 2) {
-          greenDays++;
-          currentStreak++;
-          if (currentStreak > longestStreak) {
-            longestStreak = currentStreak;
+        if (state === 1) {
+          colorCounts.red++;
+          currentStreaks.red++;
+          currentStreaks.green = 0;
+          currentStreaks.blue = 0;
+          currentGreenBlueStreak = 0;
+          if (currentStreaks.red > longestStreaks.red) {
+            longestStreaks.red = currentStreaks.red;
+          }
+        } else if (state === 2) {
+          colorCounts.green++;
+          currentStreaks.green++;
+          currentStreaks.red = 0;
+          currentStreaks.blue = 0;
+          currentGreenBlueStreak++;
+          if (currentGreenBlueStreak > longestGreenBlueStreak) {
+            longestGreenBlueStreak = currentGreenBlueStreak;
+          }
+          if (currentStreaks.green > longestStreaks.green) {
+            longestStreaks.green = currentStreaks.green;
+          }
+        } else if (state === 3) {
+          colorCounts.blue++;
+          currentStreaks.blue++;
+          currentStreaks.red = 0;
+          currentStreaks.green = 0;
+          currentGreenBlueStreak++;
+          if (currentGreenBlueStreak > longestGreenBlueStreak) {
+            longestGreenBlueStreak = currentGreenBlueStreak;
+          }
+          if (currentStreaks.blue > longestStreaks.blue) {
+            longestStreaks.blue = currentStreaks.blue;
           }
         } else {
-          currentStreak = 0;
+          currentStreaks.red = 0;
+          currentStreaks.green = 0;
+          currentStreaks.blue = 0;
+          currentGreenBlueStreak = 0;
         }
       }
-      stats.textContent = `Green days: ${greenDays}/${daysPassed}, Longest green streak: ${longestStreak}`;
+      stats.innerHTML = [
+        `Green days: ${colorCounts.green}/${daysPassed}, Longest green streak: ${longestStreaks.green}`,
+        `Red days: ${colorCounts.red}/${daysPassed}, Longest red streak: ${longestStreaks.red}`,
+        `Blue days: ${colorCounts.blue}/${daysPassed}, Longest blue streak: ${longestStreaks.blue}`,
+        `Longest green or blue streak: ${longestGreenBlueStreak}`,
+      ].join('<br>');
     };
     const cells = generateCalendar(year, month - 1);
     cells.forEach((value) => {


### PR DESCRIPTION
## Summary
- lighten the blue day styling to a lighter shade for improved contrast
- compute monthly counts and longest streaks for all streak colors and render them below each calendar
- expand the stats unit test to verify the red, green, and blue outputs
- track the combined longest green-or-blue streak alongside the individual streak metrics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c17af5c0832a8a324dbe822b5fa1