### PR TITLE
Ensure held results stay mutually exclusive

### DIFF
--- a/Commitment/src/main.ts
+++ b/Commitment/src/main.ts
@@ -99,19 +99,29 @@ export function setup() {
 
   const recordSuccess = (firstSetAt: number) => {
     const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
+    const failures = JSON.parse(localStorage.getItem(HELD_FAILURE_KEY) || '[]');
     const dateStr = getDateKey(new Date(firstSetAt));
     if (!successes.includes(dateStr)) {
       successes.push(dateStr);
       localStorage.setItem(HELD_SUCCESS_KEY, JSON.stringify(successes));
     }
+    if (failures.includes(dateStr)) {
+      const nextFailures = failures.filter((date: string) => date !== dateStr);
+      localStorage.setItem(HELD_FAILURE_KEY, JSON.stringify(nextFailures));
+    }
   };
 
   const recordFailure = (firstSetAt: number) => {
+    const successes = JSON.parse(localStorage.getItem(HELD_SUCCESS_KEY) || '[]');
     const failures = JSON.parse(localStorage.getItem(HELD_FAILURE_KEY) || '[]');
     const dateStr = getDateKey(new Date(firstSetAt));
     if (!failures.includes(dateStr)) {
       failures.push(dateStr);
       localStorage.setItem(HELD_FAILURE_KEY, JSON.stringify(failures));
+    }
+    if (successes.includes(dateStr)) {
+      const nextSuccesses = successes.filter((date: string) => date !== dateStr);
+      localStorage.setItem(HELD_SUCCESS_KEY, JSON.stringify(nextSuccesses));
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure recording a held success removes any stored failure for that day and vice versa so results remain exclusive

## Testing
- `cd Commitment && npm test`
- `cd StreakTracker && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cc018d08d0832a9cc4ef99ac06c5ce