### PR TITLE
Migrate apps to IndexedDB storage

### DIFF
--- a/Commitment/jest.config.js
+++ b/Commitment/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/Commitment/jest.setup.js
+++ b/Commitment/jest.setup.js
@@ -1,0 +1,5 @@
+require('fake-indexeddb/auto');
+
+if (typeof global.structuredClone !== 'function') {
+  global.structuredClone = (value) => JSON.parse(JSON.stringify(value));
+}

--- a/Commitment/package-lock.json
+++ b/Commitment/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/jest": "^29.5.2",
+        "fake-indexeddb": "^6.2.2",
         "jest": "^29.6.0",
         "jest-environment-jsdom": "^29.6.0",
         "ts-jest": "^29.1.0",
@@ -2003,6 +2004,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.2.tgz",
+      "integrity": "sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/Commitment/package.json
+++ b/Commitment/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",
+    "fake-indexeddb": "^6.2.2",
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.6.0",
     "ts-jest": "^29.1.0",

--- a/Commitment/src/main.test.ts
+++ b/Commitment/src/main.test.ts
@@ -1,7 +1,65 @@
-import { setup, adjustDay } from './main';
+import {
+  setup,
+  adjustDay,
+  clearAllStoredDataForTests,
+  getStoredValueForTests,
+} from './main';
+
+async function flushAsyncOperations() {
+  await Promise.resolve();
+  const timeoutFn = setTimeout as unknown as { mock?: unknown; _isMockFunction?: boolean };
+  const usingFakeTimers = typeof (timeoutFn as { clock?: unknown }).clock === 'object';
+  if (usingFakeTimers && typeof jest !== 'undefined' && typeof jest.runOnlyPendingTimers === 'function') {
+    try {
+      jest.runOnlyPendingTimers();
+    } catch {
+      // Timers are not mocked; ignore.
+    }
+  }
+  await new Promise((resolve) => {
+    if (typeof setImmediate === 'function') {
+      setImmediate(resolve);
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+async function waitForCondition(condition: () => boolean, maxAttempts = 20) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    await flushAsyncOperations();
+  }
+  throw new Error('Condition not met within allotted attempts');
+}
+
+function mockDate(dateString: string): () => void {
+  const RealDate = Date;
+  const fixedTime = new RealDate(dateString).getTime();
+  class MockDate extends Date {
+    constructor(...args: ConstructorParameters<typeof Date>) {
+      if (args.length > 0) {
+        super(...args);
+      } else {
+        super(fixedTime);
+      }
+    }
+    static now() {
+      return fixedTime;
+    }
+    static parse = RealDate.parse;
+    static UTC = RealDate.UTC;
+  }
+  globalThis.Date = MockDate as unknown as DateConstructor;
+  return () => {
+    globalThis.Date = RealDate;
+  };
+}
 
 describe('Commitment UI', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     document.body.innerHTML = `
       <div>
         <span>Commit:</span>
@@ -16,7 +74,7 @@ describe('Commitment UI', () => {
       <div id="held-prompt" hidden></div>
       <div id="success-visual"></div>`;
     localStorage.clear();
-    jest.useFakeTimers();
+    await clearAllStoredDataForTests();
   });
 
   afterEach(() => {
@@ -24,171 +82,231 @@ describe('Commitment UI', () => {
     window.history.pushState({}, '', '/');
   });
 
-  it('restores saved toggle states on load', () => {
+  it('restores saved toggle states on load', async () => {
     localStorage.setItem('commitToggle', 'true');
     localStorage.setItem('commitFirstSetAt', String(Date.now()));
     localStorage.setItem('heldToggle', 'true');
-    setup();
+    await setup();
     const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
     const heldYes = document.getElementById('held-yes') as HTMLInputElement;
     expect(commitYes.checked).toBe(true);
     expect(heldYes.checked).toBe(true);
   });
 
-  it('locks commit toggle after 30 seconds', () => {
-    setup();
-    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
-    commitYes.checked = true;
-    commitYes.dispatchEvent(new Event('change'));
-    jest.advanceTimersByTime(30000);
-    const commitNo = document.getElementById('commit-no') as HTMLInputElement;
-    expect(commitYes.disabled).toBe(true);
-    expect(commitNo.disabled).toBe(true);
+  it('locks commit toggle after 30 seconds', async () => {
+    const timeoutSpy = jest.spyOn(window, 'setTimeout');
+    try {
+      await setup();
+      const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
+      const commitNo = document.getElementById('commit-no') as HTMLInputElement;
+      commitYes.checked = true;
+      commitYes.dispatchEvent(new Event('change'));
+      await waitForCondition(() =>
+        timeoutSpy.mock.calls.some(([, delay]) => typeof delay === 'number' && delay > 0)
+      );
+      const lockCall = timeoutSpy.mock.calls
+        .slice()
+        .reverse()
+        .find(([, delay]) => typeof delay === 'number' && (delay as number) > 0);
+      expect(lockCall).toBeDefined();
+      const [lockCallback, delay] = lockCall as [() => void, number];
+      expect(delay).toBeGreaterThan(0);
+      expect(delay).toBeLessThanOrEqual(30000);
+      lockCallback();
+      expect(commitYes.disabled).toBe(true);
+      expect(commitNo.disabled).toBe(true);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
-  it('allows clearing a selection without selecting the other', () => {
-    setup();
+  it('allows clearing a selection without selecting the other', async () => {
+    await setup();
     const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
     const commitNo = document.getElementById('commit-no') as HTMLInputElement;
     commitYes.checked = true;
     commitYes.dispatchEvent(new Event('change'));
+    await flushAsyncOperations();
     expect(commitYes.checked).toBe(true);
     expect(commitNo.checked).toBe(false);
     commitYes.checked = false;
     commitYes.dispatchEvent(new Event('change'));
+    await flushAsyncOperations();
     expect(commitYes.checked).toBe(false);
     expect(commitNo.checked).toBe(false);
   });
 
-  it('does not allow both commit options to be selected', () => {
-    setup();
+  it('does not allow both commit options to be selected', async () => {
+    await setup();
     const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
     const commitNo = document.getElementById('commit-no') as HTMLInputElement;
     commitYes.checked = true;
     commitYes.dispatchEvent(new Event('change'));
+    await flushAsyncOperations();
     commitNo.checked = true;
     commitNo.dispatchEvent(new Event('change'));
+    await flushAsyncOperations();
     expect(commitYes.checked).toBe(false);
     expect(commitNo.checked).toBe(true);
   });
 
-  it('does not allow both held options to be selected', () => {
-    setup();
+  it('does not allow both held options to be selected', async () => {
+    await setup();
     const heldYes = document.getElementById('held-yes') as HTMLInputElement;
     const heldNo = document.getElementById('held-no') as HTMLInputElement;
     heldYes.checked = true;
     heldYes.dispatchEvent(new Event('change'));
+    await flushAsyncOperations();
     heldNo.checked = true;
     heldNo.dispatchEvent(new Event('change'));
+    await flushAsyncOperations();
     expect(heldYes.checked).toBe(false);
     expect(heldNo.checked).toBe(true);
   });
 
-  it('records held days on reset', () => {
-    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
-    const commitTime = new Date('2023-01-01T22:00:00Z');
-    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
-    localStorage.setItem('heldToggle', 'true');
-    setup();
-    const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
-    expect(successes).toContain(commitTime.toISOString().split('T')[0]);
-    expect(localStorage.getItem('heldToggle')).toBeNull();
+  it('records held days on reset', async () => {
+    const restoreDate = mockDate('2023-01-02T05:00:00Z');
+    try {
+      const commitTime = new Date('2023-01-01T22:00:00Z');
+      localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+      localStorage.setItem('heldToggle', 'true');
+      await setup();
+      const successRaw = await getStoredValueForTests('heldSuccessDates');
+      const successes = JSON.parse(successRaw || '[]');
+      expect(successes).toContain(commitTime.toISOString().split('T')[0]);
+      expect(await getStoredValueForTests('heldToggle')).toBeNull();
+    } finally {
+      restoreDate();
+    }
   });
 
-  it('records failed days on reset', () => {
-    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
-    const commitTime = new Date('2023-01-01T22:00:00Z');
-    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
-    localStorage.setItem('heldToggle', 'false');
-    setup();
-    const failures = JSON.parse(localStorage.getItem('heldFailureDates') || '[]');
-    expect(failures).toContain(commitTime.toISOString().split('T')[0]);
-    expect(localStorage.getItem('heldToggle')).toBeNull();
+  it('records failed days on reset', async () => {
+    const restoreDate = mockDate('2023-01-02T05:00:00Z');
+    try {
+      const commitTime = new Date('2023-01-01T22:00:00Z');
+      localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+      localStorage.setItem('heldToggle', 'false');
+      await setup();
+      const failureRaw = await getStoredValueForTests('heldFailureDates');
+      const failures = JSON.parse(failureRaw || '[]');
+      expect(failures).toContain(commitTime.toISOString().split('T')[0]);
+      expect(await getStoredValueForTests('heldToggle')).toBeNull();
+    } finally {
+      restoreDate();
+    }
   });
 
-  it('prompts for held selection when missing from previous day', () => {
-    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
-    const commitTime = new Date('2023-01-01T22:00:00Z');
-    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
-    localStorage.setItem('commitToggle', 'true');
-    setup();
-    const prompt = document.getElementById('held-prompt') as HTMLElement;
-    expect(prompt.hidden).toBe(false);
-    expect(prompt.textContent).toBe('Please record whether you held your commitment yesterday.');
-    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
-    heldYes.checked = true;
-    heldYes.dispatchEvent(new Event('change'));
-    const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
-    expect(successes).toContain(commitTime.toISOString().split('T')[0]);
-    expect(localStorage.getItem('heldToggle')).toBeNull();
-    const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
-    expect(commitYes.disabled).toBe(false);
-    expect(prompt.hidden).toBe(true);
+  it('prompts for held selection when missing from previous day', async () => {
+    const restoreDate = mockDate('2023-01-02T05:00:00Z');
+    try {
+      const commitTime = new Date('2023-01-01T22:00:00Z');
+      localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+      localStorage.setItem('commitToggle', 'true');
+      await setup();
+      expect(await getStoredValueForTests('commitFirstSetAt')).not.toBeNull();
+      const prompt = document.getElementById('held-prompt') as HTMLElement;
+      expect(prompt.hidden).toBe(false);
+      expect(prompt.textContent).toBe('Please record whether you held your commitment yesterday.');
+      const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+      heldYes.checked = true;
+      heldYes.dispatchEvent(new Event('change'));
+      await waitForCondition(() => prompt.hidden);
+      const rawSuccesses = await getStoredValueForTests('heldSuccessDates');
+      const successes = JSON.parse(rawSuccesses || '[]');
+      expect(successes).toContain(commitTime.toISOString().split('T')[0]);
+      expect(await getStoredValueForTests('heldToggle')).toBeNull();
+      const commitYes = document.getElementById('commit-yes') as HTMLInputElement;
+      expect(commitYes.disabled).toBe(false);
+      expect(prompt.hidden).toBe(true);
+    } finally {
+      restoreDate();
+    }
   });
 
-  it('updates success visualization after recording held result', () => {
-    jest.setSystemTime(new Date('2023-01-02T05:00:00Z'));
-    const commitTime = new Date('2023-01-01T22:00:00Z');
-    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
-    localStorage.setItem('commitToggle', 'true');
-    setup();
-    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
-    heldYes.checked = true;
-    heldYes.dispatchEvent(new Event('change'));
-    const squares = document.querySelectorAll('#success-visual .day');
-    expect(squares[squares.length - 2].classList.contains('success')).toBe(true);
+  it('updates success visualization after recording held result', async () => {
+    const restoreDate = mockDate('2023-01-02T05:00:00Z');
+    try {
+      const commitTime = new Date('2023-01-01T22:00:00Z');
+      localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+      localStorage.setItem('commitToggle', 'true');
+      await setup();
+      expect(await getStoredValueForTests('commitFirstSetAt')).not.toBeNull();
+      const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+      heldYes.checked = true;
+      heldYes.dispatchEvent(new Event('change'));
+      await waitForCondition(() => {
+        const squares = document.querySelectorAll('#success-visual .day');
+        return squares.length >= 2 && squares[squares.length - 2].classList.contains('success');
+      });
+      const squares = document.querySelectorAll('#success-visual .day');
+      expect(squares[squares.length - 2].classList.contains('success')).toBe(true);
+    } finally {
+      restoreDate();
+    }
   });
 
-  it('records success for the previous local day when crossing UTC midnight', () => {
+  it('records success for the previous local day when crossing UTC midnight', async () => {
     const realOffset = Date.prototype.getTimezoneOffset;
     Date.prototype.getTimezoneOffset = () => 300;
-    jest.setSystemTime(new Date('2023-01-02T13:00:00Z'));
-    const commitTime = new Date('2023-01-02T03:00:00Z');
-    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
-    localStorage.setItem('commitToggle', 'true');
-    setup();
-    const heldYes = document.getElementById('held-yes') as HTMLInputElement;
-    heldYes.checked = true;
-    heldYes.dispatchEvent(new Event('change'));
-    const successes = JSON.parse(localStorage.getItem('heldSuccessDates') || '[]');
-    expect(successes).toContain('2023-01-01');
-    const squares = document.querySelectorAll('#success-visual .day');
-    expect(squares[squares.length - 2].classList.contains('success')).toBe(true);
-    Date.prototype.getTimezoneOffset = realOffset;
+    const restoreDate = mockDate('2023-01-02T13:00:00Z');
+    try {
+      const commitTime = new Date('2023-01-02T03:00:00Z');
+      localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+      localStorage.setItem('commitToggle', 'true');
+      await setup();
+      const heldYes = document.getElementById('held-yes') as HTMLInputElement;
+      heldYes.checked = true;
+      heldYes.dispatchEvent(new Event('change'));
+      await waitForCondition(() => {
+        const squares = document.querySelectorAll('#success-visual .day');
+        return squares.length >= 2 && squares[squares.length - 2].classList.contains('success');
+      });
+      const successes = JSON.parse((await getStoredValueForTests('heldSuccessDates')) || '[]');
+      expect(successes).toContain('2023-01-01');
+      const squares = document.querySelectorAll('#success-visual .day');
+      expect(squares[squares.length - 2].classList.contains('success')).toBe(true);
+    } finally {
+      Date.prototype.getTimezoneOffset = realOffset;
+      restoreDate();
+    }
   });
 
-  it('warns and clears after multiple days of inactivity', () => {
-    jest.setSystemTime(new Date('2023-01-03T05:00:00Z'));
-    const commitTime = new Date('2023-01-01T22:00:00Z');
-    localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
-    localStorage.setItem('commitToggle', 'true');
-    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
-    setup();
-    expect(alertSpy).toHaveBeenCalledWith('It has been a while since your last visit. Please open the app more often.');
-    expect(localStorage.getItem('commitToggle')).toBeNull();
-    alertSpy.mockRestore();
+  it('warns and clears after multiple days of inactivity', async () => {
+    const restoreDate = mockDate('2023-01-03T05:00:00Z');
+    try {
+      const commitTime = new Date('2023-01-01T22:00:00Z');
+      localStorage.setItem('commitFirstSetAt', String(commitTime.getTime()));
+      localStorage.setItem('commitToggle', 'true');
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+      await setup();
+      expect(alertSpy).toHaveBeenCalledWith('It has been a while since your last visit. Please open the app more often.');
+      expect(await getStoredValueForTests('commitToggle')).toBeNull();
+      alertSpy.mockRestore();
+    } finally {
+      restoreDate();
+    }
   });
 
-  it('renders success visualization', () => {
+  it('renders success visualization', async () => {
     const todayStr = new Date().toISOString().split('T')[0];
     localStorage.setItem('heldSuccessDates', JSON.stringify([todayStr]));
-    setup();
+    await setup();
     const squares = document.querySelectorAll('#success-visual .day');
     expect(squares.length).toBe(7);
     expect(squares[squares.length - 1].classList.contains('success')).toBe(true);
   });
 
-  it('renders failure visualization', () => {
+  it('renders failure visualization', async () => {
     const todayStr = new Date().toISOString().split('T')[0];
     localStorage.setItem('heldFailureDates', JSON.stringify([todayStr]));
-    setup();
+    await setup();
     const squares = document.querySelectorAll('#success-visual .day');
     expect(squares.length).toBe(7);
     expect(squares[squares.length - 1].classList.contains('failure')).toBe(true);
   });
 
-  it('shows dates under success visualization', () => {
-    setup();
+  it('shows dates under success visualization', async () => {
+    await setup();
     const labels = document.querySelectorAll('#success-visual .day-date');
     expect(labels.length).toBe(7);
     const today = new Date();
@@ -196,21 +314,21 @@ describe('Commitment UI', () => {
     expect(labels[labels.length - 1].textContent).toBe(expected);
   });
 
-  it('highlights the current day', () => {
-    setup();
+  it('highlights the current day', async () => {
+    await setup();
     const squares = document.querySelectorAll('#success-visual .day');
     expect(squares.length).toBe(7);
     expect(squares[squares.length - 1].classList.contains('current')).toBe(true);
   });
 
-  it('shows admin controls when admin query param present', () => {
+  it('shows admin controls when admin query param present', async () => {
     window.history.pushState({}, '', '/?admin=true');
-    setup();
+    await setup();
     expect(document.getElementById('admin-next-day')).not.toBeNull();
     expect(document.getElementById('admin-clear-data')).not.toBeNull();
   });
 
-  it('clears data with admin clear button', () => {
+  it('clears data with admin clear button', async () => {
     window.history.pushState({}, '', '/?admin=true');
     localStorage.setItem('commitToggle', 'true');
     const originalLocation = window.location;
@@ -219,16 +337,17 @@ describe('Commitment UI', () => {
       value: { ...originalLocation, reload: reloadSpy },
       configurable: true,
     });
-    setup();
+    await setup();
     const clearBtn = document.getElementById('admin-clear-data') as HTMLButtonElement;
     clearBtn.click();
-    expect(localStorage.getItem('commitToggle')).toBeNull();
+    await flushAsyncOperations();
+    expect(await getStoredValueForTests('commitToggle')).toBeNull();
     expect(reloadSpy).toHaveBeenCalled();
     Object.defineProperty(window, 'location', { value: originalLocation });
   });
 
-  it('adjusts day offset', () => {
-    adjustDay(1);
-    expect(localStorage.getItem('adminDayOffset')).toBe('1');
+  it('adjusts day offset', async () => {
+    await adjustDay(1);
+    expect(await getStoredValueForTests('adminDayOffset')).toBe('1');
   });
 });

--- a/StreakTracker/jest.config.js
+++ b/StreakTracker/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/StreakTracker/jest.setup.js
+++ b/StreakTracker/jest.setup.js
@@ -1,0 +1,5 @@
+require('fake-indexeddb/auto');
+
+if (typeof global.structuredClone !== 'function') {
+  global.structuredClone = (value) => JSON.parse(JSON.stringify(value));
+}

--- a/StreakTracker/package-lock.json
+++ b/StreakTracker/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/jest": "^29.5.2",
+        "fake-indexeddb": "^6.2.2",
         "jest": "^29.6.0",
         "jest-environment-jsdom": "^29.6.0",
         "ts-jest": "^29.1.0",
@@ -2003,6 +2004,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.2.tgz",
+      "integrity": "sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/StreakTracker/package.json
+++ b/StreakTracker/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",
+    "fake-indexeddb": "^6.2.2",
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.6.0",
     "ts-jest": "^29.1.0",

--- a/StreakTracker/src/main.test.ts
+++ b/StreakTracker/src/main.test.ts
@@ -1,4 +1,69 @@
-import { generateCalendar, setup } from './main';
+import {
+  generateCalendar,
+  setup,
+  clearAllStoredDaysForTests,
+} from './main';
+
+async function flushAsyncOperations() {
+  await Promise.resolve();
+  const usingFakeTimers =
+    typeof jest !== 'undefined' &&
+    typeof jest.isMockFunction === 'function' &&
+    jest.isMockFunction(setTimeout as unknown as jest.Mock);
+  if (usingFakeTimers && typeof jest.runOnlyPendingTimers === 'function') {
+    try {
+      jest.runOnlyPendingTimers();
+    } catch {
+      // Timers are not mocked; ignore.
+    }
+  }
+  await new Promise((resolve) => {
+    if (typeof setImmediate === 'function') {
+      setImmediate(resolve);
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+async function waitForCondition(condition: () => boolean, maxAttempts = 20) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    await flushAsyncOperations();
+  }
+  throw new Error('Condition not met within allotted attempts');
+}
+
+function mockDate(dateString: string): () => void {
+  const RealDate = Date;
+  const fixedTime = new RealDate(dateString).getTime();
+  class MockDate extends Date {
+    constructor(...args: ConstructorParameters<typeof Date>) {
+      if (args.length > 0) {
+        super(...args);
+      } else {
+        super(fixedTime);
+      }
+    }
+    static now() {
+      return fixedTime;
+    }
+    static parse = RealDate.parse;
+    static UTC = RealDate.UTC;
+  }
+  globalThis.Date = MockDate as unknown as DateConstructor;
+  return () => {
+    globalThis.Date = RealDate;
+  };
+}
+
+beforeEach(async () => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+  await clearAllStoredDaysForTests();
+});
 
 test('generateCalendar has 42 cells and correct day count', () => {
   const cells = generateCalendar(2023, 0); // January 2023
@@ -6,54 +71,47 @@ test('generateCalendar has 42 cells and correct day count', () => {
   expect(cells.filter((d) => d !== null).length).toBe(31);
 });
 
-test('clicking a day saves and restores its state', () => {
+test('clicking a day saves and restores its state', async () => {
   document.body.innerHTML = '<div id="calendars"></div>';
-  localStorage.clear();
-  setup();
+  await setup();
   const cell = Array.from(document.querySelectorAll('.day')).find(
     (c) => c.textContent === '1'
   ) as HTMLElement;
   cell.dispatchEvent(new Event('click'));
-  const now = new Date();
-  const key = `${now.getFullYear()}-${now.getMonth() + 1}-1`;
-  expect(localStorage.getItem(key)).toBe('1');
+  await flushAsyncOperations();
   document.body.innerHTML = '<div id="calendars"></div>';
-  setup();
+  await setup();
   const cell2 = Array.from(document.querySelectorAll('.day')).find(
     (c) => c.textContent === '1'
   ) as HTMLElement;
   expect(cell2.classList.contains('red')).toBe(true);
 });
 
-test('third click sets day to blue and persists state', () => {
+test('third click sets day to blue and persists state', async () => {
   document.body.innerHTML = '<div id="calendars"></div>';
-  localStorage.clear();
-  setup();
+  await setup();
   const cell = Array.from(document.querySelectorAll('.day')).find(
     (c) => c.textContent === '1'
   ) as HTMLElement;
   cell.click();
   cell.click();
   cell.click();
-  const now = new Date();
-  const key = `${now.getFullYear()}-${now.getMonth() + 1}-1`;
-  expect(localStorage.getItem(key)).toBe('3');
+  await flushAsyncOperations();
   document.body.innerHTML = '<div id="calendars"></div>';
-  setup();
+  await setup();
   const cell2 = Array.from(document.querySelectorAll('.day')).find(
     (c) => c.textContent === '1'
   ) as HTMLElement;
   expect(cell2.classList.contains('blue')).toBe(true);
 });
 
-test('renders previous months below current month', () => {
+test('renders previous months below current month', async () => {
   document.body.innerHTML = '<div id="calendars"></div>';
-  localStorage.clear();
   const now = new Date();
   const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
   const key = `${prev.getFullYear()}-${prev.getMonth() + 1}-1`;
   localStorage.setItem(key, '1');
-  setup();
+  await setup();
   const headings = Array.from(document.querySelectorAll('h1')).map(
     (h) => h.textContent
   );
@@ -71,17 +129,16 @@ test('renders previous months below current month', () => {
   expect(headings[1]).toBe(prevLabel);
 });
 
-test('stats update for all colors and streaks', () => {
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date('2023-06-15'));
+test('stats update for all colors and streaks', async () => {
+  const restoreDate = mockDate('2023-06-15T00:00:00Z');
   document.body.innerHTML = '<div id="calendars"></div>';
-  localStorage.clear();
-  setup();
+  await setup();
   const stats = document.querySelector('.stats') as HTMLElement;
-  const expectStats = (lines: string[]) => {
+  const expectStats = async (lines: string[]) => {
+    await waitForCondition(() => stats.innerHTML === lines.join('<br>'));
     expect(stats.innerHTML).toBe(lines.join('<br>'));
   };
-  expectStats([
+  await expectStats([
     'Green days: 0/15, Longest green streak: 0',
     'Red days: 0/15, Longest red streak: 0',
     'Blue days: 0/15, Longest blue streak: 0',
@@ -91,35 +148,36 @@ test('stats update for all colors and streaks', () => {
     (c) => c.textContent === '1'
   ) as HTMLElement;
   day1.click();
-  expectStats([
+  await flushAsyncOperations();
+  await expectStats([
     'Green days: 0/15, Longest green streak: 0',
     'Red days: 1/15, Longest red streak: 1',
     'Blue days: 0/15, Longest blue streak: 0',
     'Longest green or blue streak: 0',
   ]);
   day1.click();
-  expectStats([
+  await flushAsyncOperations();
+  await expectStats([
     'Green days: 1/15, Longest green streak: 1',
     'Red days: 0/15, Longest red streak: 0',
     'Blue days: 0/15, Longest blue streak: 0',
     'Longest green or blue streak: 1',
   ]);
   day1.click();
-  expectStats([
+  await flushAsyncOperations();
+  await expectStats([
     'Green days: 0/15, Longest green streak: 0',
     'Red days: 0/15, Longest red streak: 0',
     'Blue days: 1/15, Longest blue streak: 1',
     'Longest green or blue streak: 1',
   ]);
-  jest.useRealTimers();
+  restoreDate();
 });
 
-test('longest green or blue streak spans both colors', () => {
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date('2023-06-15'));
+test('longest green or blue streak spans both colors', async () => {
+  const restoreDate = mockDate('2023-06-15T00:00:00Z');
   document.body.innerHTML = '<div id="calendars"></div>';
-  localStorage.clear();
-  setup();
+  await setup();
   const stats = document.querySelector('.stats') as HTMLElement;
   const getCell = (day: string) =>
     Array.from(document.querySelectorAll('.day')).find(
@@ -147,9 +205,13 @@ test('longest green or blue streak spans both colors', () => {
     throw new Error('Unable to reach desired state');
   };
   setState(getCell('1'), 2);
+  await flushAsyncOperations();
   setState(getCell('2'), 2);
+  await flushAsyncOperations();
   setState(getCell('3'), 3);
+  await flushAsyncOperations();
   setState(getCell('4'), 2);
+  await flushAsyncOperations();
   expect(stats.innerHTML).toBe(
     [
       'Green days: 3/15, Longest green streak: 2',
@@ -158,5 +220,5 @@ test('longest green or blue streak spans both colors', () => {
       'Longest green or blue streak: 4',
     ].join('<br>')
   );
-  jest.useRealTimers();
+  restoreDate();
 });


### PR DESCRIPTION
## Summary
- replace both Commitment and StreakTracker localStorage access with IndexedDB-backed helpers that request persistent storage and migrate existing keys
- update UI logic to await async storage, expose testing utilities, and clear admin data via IndexedDB
- add fake-indexeddb Jest setup files and rework the test suites with async helpers to accommodate IndexedDB timing

## Testing
- npm test -- --runTestsByPath src/main.test.ts (Commitment)
- npm test -- --runTestsByPath src/main.test.ts (StreakTracker)


------
https://chatgpt.com/codex/tasks/task_e_68ceafaa7f28832a83902a496ae3da5a