### PR TITLE
Add patterned streak indicators and update stats display

### DIFF
--- a/StreakTracker/index.html
+++ b/StreakTracker/index.html
@@ -11,25 +11,102 @@
       font-family: Arial, sans-serif;
       padding: 1rem;
     }
+    section + section {
+      margin-top: 2rem;
+    }
     .calendar {
       display: grid;
       grid-template-columns: repeat(7, 1fr);
-      gap: 2px;
+      gap: 4px;
       margin-bottom: 1rem;
     }
     .day {
       border: 1px solid #ccc;
       height: 80px;
       cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      border-radius: 6px;
+      background-color: #fff;
+      color: #333;
+      user-select: none;
+      transition: background-color 0.2s ease, background-image 0.2s ease, color 0.2s ease;
     }
-    .day.red {
-      background-color: red;
+    .day.red,
+    .stat-swatch.red {
+      background-color: #d32f2f;
+      background-image: repeating-linear-gradient(
+        45deg,
+        rgba(255, 255, 255, 0.35) 0px,
+        rgba(255, 255, 255, 0.35) 10px,
+        rgba(255, 255, 255, 0) 10px,
+        rgba(255, 255, 255, 0) 20px
+      );
+      color: #fff;
     }
-    .day.green {
-      background-color: green;
+    .day.green,
+    .stat-swatch.green {
+      background-color: #2e7d32;
+      background-image: repeating-linear-gradient(
+        -45deg,
+        rgba(255, 255, 255, 0.35) 0px,
+        rgba(255, 255, 255, 0.35) 10px,
+        rgba(255, 255, 255, 0) 10px,
+        rgba(255, 255, 255, 0) 20px
+      );
+      color: #fff;
     }
-    .day.blue {
-      background-color: #87cefa;
+    .day.blue,
+    .stat-swatch.blue {
+      background-color: #1565c0;
+      background-image: repeating-linear-gradient(
+        0deg,
+        rgba(255, 255, 255, 0.35) 0px,
+        rgba(255, 255, 255, 0.35) 8px,
+        rgba(255, 255, 255, 0) 8px,
+        rgba(255, 255, 255, 0) 16px
+      );
+      color: #fff;
+    }
+    .stats {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+    }
+    .stat-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      position: relative;
+    }
+    .stat-swatch {
+      width: 18px;
+      height: 18px;
+      border-radius: 3px;
+      border: 1px solid rgba(0, 0, 0, 0.3);
+      background-size: 20px 20px;
+      flex-shrink: 0;
+    }
+    .stat-swatch-group {
+      display: flex;
+      gap: 0.25rem;
+    }
+    .stat-text {
+      line-height: 1.3;
+    }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
   </style>
 </head>

--- a/StreakTracker/src/main.test.ts
+++ b/StreakTracker/src/main.test.ts
@@ -78,39 +78,59 @@ test('stats update for all colors and streaks', () => {
   localStorage.clear();
   setup();
   const stats = document.querySelector('.stats') as HTMLElement;
-  const expectStats = (lines: string[]) => {
-    expect(stats.innerHTML).toBe(lines.join('<br>'));
+  const getColorRowText = (color: string) =>
+    (stats.querySelector(`.stat-row[data-color="${color}"] .stat-text`) as HTMLElement)
+      .textContent;
+  const getCombinedText = () =>
+    (stats.querySelector(
+      '.stat-row[data-combination="green-blue"] .stat-text'
+    ) as HTMLElement).textContent;
+  const expectStats = (expected: {
+    green: string;
+    red: string;
+    blue: string;
+    combined: string;
+  }) => {
+    expect(getColorRowText('green')).toBe(expected.green);
+    expect(getColorRowText('red')).toBe(expected.red);
+    expect(getColorRowText('blue')).toBe(expected.blue);
+    expect(getCombinedText()).toBe(expected.combined);
   };
-  expectStats([
-    'Green days: 0/15, Longest green streak: 0',
-    'Red days: 0/15, Longest red streak: 0',
-    'Blue days: 0/15, Longest blue streak: 0',
-    'Longest green or blue streak: 0',
-  ]);
+  expect(stats.querySelectorAll('.stat-row').length).toBe(4);
+  expect(stats.querySelectorAll('.stat-swatch').length).toBe(5);
+  expect(
+    stats.querySelectorAll('.stat-row[data-combination="green-blue"] .stat-swatch').length
+  ).toBe(2);
+  expectStats({
+    green: 'Days: 0/15, Longest streak: 0',
+    red: 'Days: 0/15, Longest streak: 0',
+    blue: 'Days: 0/15, Longest streak: 0',
+    combined: 'Longest combined streak: 0',
+  });
   const day1 = Array.from(document.querySelectorAll('.day')).find(
     (c) => c.textContent === '1'
   ) as HTMLElement;
   day1.click();
-  expectStats([
-    'Green days: 0/15, Longest green streak: 0',
-    'Red days: 1/15, Longest red streak: 1',
-    'Blue days: 0/15, Longest blue streak: 0',
-    'Longest green or blue streak: 0',
-  ]);
+  expectStats({
+    green: 'Days: 0/15, Longest streak: 0',
+    red: 'Days: 1/15, Longest streak: 1',
+    blue: 'Days: 0/15, Longest streak: 0',
+    combined: 'Longest combined streak: 0',
+  });
   day1.click();
-  expectStats([
-    'Green days: 1/15, Longest green streak: 1',
-    'Red days: 0/15, Longest red streak: 0',
-    'Blue days: 0/15, Longest blue streak: 0',
-    'Longest green or blue streak: 1',
-  ]);
+  expectStats({
+    green: 'Days: 1/15, Longest streak: 1',
+    red: 'Days: 0/15, Longest streak: 0',
+    blue: 'Days: 0/15, Longest streak: 0',
+    combined: 'Longest combined streak: 1',
+  });
   day1.click();
-  expectStats([
-    'Green days: 0/15, Longest green streak: 0',
-    'Red days: 0/15, Longest red streak: 0',
-    'Blue days: 1/15, Longest blue streak: 1',
-    'Longest green or blue streak: 1',
-  ]);
+  expectStats({
+    green: 'Days: 0/15, Longest streak: 0',
+    red: 'Days: 0/15, Longest streak: 0',
+    blue: 'Days: 1/15, Longest streak: 1',
+    combined: 'Longest combined streak: 1',
+  });
   jest.useRealTimers();
 });
 
@@ -150,13 +170,16 @@ test('longest green or blue streak spans both colors', () => {
   setState(getCell('2'), 2);
   setState(getCell('3'), 3);
   setState(getCell('4'), 2);
-  expect(stats.innerHTML).toBe(
-    [
-      'Green days: 3/15, Longest green streak: 2',
-      'Red days: 0/15, Longest red streak: 0',
-      'Blue days: 1/15, Longest blue streak: 1',
-      'Longest green or blue streak: 4',
-    ].join('<br>')
-  );
+  const getColorRowText = (color: string) =>
+    (stats.querySelector(`.stat-row[data-color="${color}"] .stat-text`) as HTMLElement)
+      .textContent;
+  const getCombinedText = () =>
+    (stats.querySelector(
+      '.stat-row[data-combination="green-blue"] .stat-text'
+    ) as HTMLElement).textContent;
+  expect(getColorRowText('green')).toBe('Days: 3/15, Longest streak: 2');
+  expect(getColorRowText('red')).toBe('Days: 0/15, Longest streak: 0');
+  expect(getColorRowText('blue')).toBe('Days: 1/15, Longest streak: 1');
+  expect(getCombinedText()).toBe('Longest combined streak: 4');
   jest.useRealTimers();
 });

--- a/StreakTracker/src/main.ts
+++ b/StreakTracker/src/main.ts
@@ -8,6 +8,8 @@ export function generateCalendar(year: number, month: number): (number | null)[]
   return cells;
 }
 
+type ColorKey = 'red' | 'green' | 'blue';
+
 function getStoredMonths(now: Date): { year: number; month: number }[] {
   const months = new Set<string>();
   for (let i = 0; i < localStorage.length; i++) {
@@ -50,7 +52,7 @@ export function setup() {
 
     const calendar = document.createElement('div');
     calendar.className = 'calendar';
-    const stats = document.createElement('p');
+    const stats = document.createElement('div');
     stats.className = 'stats';
     const updateStats = () => {
       const daysInMonth = new Date(year, month, 0).getDate();
@@ -63,17 +65,17 @@ export function setup() {
       ) {
         daysPassed = daysInMonth;
       }
-      const colorCounts = {
+      const colorCounts: Record<ColorKey, number> = {
         red: 0,
         green: 0,
         blue: 0,
       };
-      const currentStreaks = {
+      const currentStreaks: Record<ColorKey, number> = {
         red: 0,
         green: 0,
         blue: 0,
       };
-      const longestStreaks = {
+      const longestStreaks: Record<ColorKey, number> = {
         red: 0,
         green: 0,
         blue: 0,
@@ -122,12 +124,58 @@ export function setup() {
           currentGreenBlueStreak = 0;
         }
       }
-      stats.innerHTML = [
-        `Green days: ${colorCounts.green}/${daysPassed}, Longest green streak: ${longestStreaks.green}`,
-        `Red days: ${colorCounts.red}/${daysPassed}, Longest red streak: ${longestStreaks.red}`,
-        `Blue days: ${colorCounts.blue}/${daysPassed}, Longest blue streak: ${longestStreaks.blue}`,
-        `Longest green or blue streak: ${longestGreenBlueStreak}`,
-      ].join('<br>');
+      stats.innerHTML = '';
+      const colorOrder: ColorKey[] = ['green', 'red', 'blue'];
+      colorOrder.forEach((color) => {
+        const row = document.createElement('div');
+        row.className = 'stat-row';
+        row.dataset.color = color;
+
+        const swatch = document.createElement('span');
+        swatch.className = `stat-swatch ${color}`;
+        swatch.setAttribute('aria-hidden', 'true');
+        row.appendChild(swatch);
+
+        const srOnly = document.createElement('span');
+        srOnly.className = 'sr-only';
+        srOnly.textContent = `${color.charAt(0).toUpperCase()}${color.slice(1)} `;
+        row.appendChild(srOnly);
+
+        const text = document.createElement('span');
+        text.className = 'stat-text';
+        text.textContent = `Days: ${colorCounts[color]}/${daysPassed}, Longest streak: ${longestStreaks[color]}`;
+        row.appendChild(text);
+
+        stats.appendChild(row);
+      });
+
+      const combinedRow = document.createElement('div');
+      combinedRow.className = 'stat-row';
+      combinedRow.dataset.combination = 'green-blue';
+
+      const swatchGroup = document.createElement('span');
+      swatchGroup.className = 'stat-swatch-group';
+
+      (['green', 'blue'] as ColorKey[]).forEach((color) => {
+        const swatch = document.createElement('span');
+        swatch.className = `stat-swatch ${color}`;
+        swatch.setAttribute('aria-hidden', 'true');
+        swatchGroup.appendChild(swatch);
+      });
+
+      combinedRow.appendChild(swatchGroup);
+
+      const combinedSrOnly = document.createElement('span');
+      combinedSrOnly.className = 'sr-only';
+      combinedSrOnly.textContent = 'Green or blue ';
+      combinedRow.appendChild(combinedSrOnly);
+
+      const combinedText = document.createElement('span');
+      combinedText.className = 'stat-text';
+      combinedText.textContent = `Longest combined streak: ${longestGreenBlueStreak}`;
+      combinedRow.appendChild(combinedText);
+
+      stats.appendChild(combinedRow);
     };
     const cells = generateCalendar(year, month - 1);
     cells.forEach((value) => {


### PR DESCRIPTION
## Summary
- add patterned backgrounds to streak day cells and stats swatches so streak states remain distinguishable in grayscale
- replace color-word labels in the stats area with patterned swatches and accessible text while keeping streak calculations unchanged
- adjust unit tests to cover the new stats layout and ensure pattern swatches render as expected

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceaf7e17b4832a8612770468720e99